### PR TITLE
docs(node): link BlenderBridge reference to Blender bridge tutorial

### DIFF
--- a/docs/node_reference/nodes/BlenderBridge.in.md
+++ b/docs/node_reference/nodes/BlenderBridge.in.md
@@ -1,0 +1,5 @@
+# Blender bridge
+
+See the [Blender Bridge documentation](../../user_manual/bridges/Blender/README.md)
+for how to install the Blender add-on and stream terrain data from Hesiod into
+Blender.

--- a/docs/node_reference/nodes/BlenderBridge.md
+++ b/docs/node_reference/nodes/BlenderBridge.md
@@ -39,3 +39,8 @@ Corresponding Hesiod file: [BlenderBridge.hsd](../../examples/BlenderBridge.hsd)
     If you find an error, please [open an issue](https://github.com/otto-link/Hesiod/issues).
 
   
+# Blender bridge
+
+See the [Blender Bridge documentation](../../user_manual/bridges/Blender/README.md)
+for how to install the Blender add-on and stream terrain data from Hesiod into
+Blender.


### PR DESCRIPTION
Closes #640.

The **BlenderBridge** node reference page had no pointer to the Blender bridge tutorial, so users landing on the node had no way to discover how to install the add-on / stream terrain into Blender.

## Change
- `docs/node_reference/nodes/BlenderBridge.in.md` — add the link (this hand-authored fragment is the source of truth; it survives `generate_node_reference.py` regeneration).
- `docs/node_reference/nodes/BlenderBridge.md` — reflect the same rendered block so the committed site matches without a full regen. The appended block byte-matches the generator's `.in.md` rendering (verified against existing nodes).

The link resolves through the committed `docs/user_manual/bridges` → `../../bridges` symlink to `bridges/Blender/README.md`, using the same relative-link convention already used in `docs/user_manual/index.md`.

## Verification
- `mkdocs build --strict` passes (EXIT 0); no new warnings.
- Rendered link on the node page resolves to `user_manual/bridges/Blender/`.