### PR TITLE
Start with a blank project instead of loading default.hsd

### DIFF
--- a/Hesiod/include/hesiod/app/app_settings.hpp
+++ b/Hesiod/include/hesiod/app/app_settings.hpp
@@ -65,7 +65,9 @@ struct AppSettings
   {
     int         omp_num_threads = 8;
     std::string icon_path = "data/hesiod_icon.png";
-    std::string default_startup_project_file = "data/default.hsd";
+    // empty = start with a blank project; set to a .hsd path to load that
+    // file at startup instead
+    std::string default_startup_project_file = "";
     std::string quick_start_html_file = "data/quick_start.html";
     std::string node_documentation_path = "data/node_documentation.json";
     std::string git_version_file = "data/git_version.txt";

--- a/Hesiod/src/app/app_settings.cpp
+++ b/Hesiod/src/app/app_settings.cpp
@@ -120,6 +120,11 @@ void AppSettings::json_from(nlohmann::json const &json)
   json_safe_get(json,
                 "global.default_startup_project_file",
                 global.default_startup_project_file);
+  // configs written before the blank-startup change persisted the old
+  // compiled default on every exit; those users expect the new blank
+  // startup, not a pinned default file
+  if (global.default_startup_project_file == "data/default.hsd")
+    global.default_startup_project_file = "";
   json_safe_get(json, "global.save_backup_file", global.save_backup_file);
   json_safe_get(json, "global.recent_files", global.recent_files);
   json_safe_get(json, "global.max_recent_files", global.max_recent_files);

--- a/Hesiod/src/app/hesiod_application.cpp
+++ b/Hesiod/src/app/hesiod_application.cpp
@@ -253,7 +253,20 @@ void HesiodApplication::load_project_model_and_ui(const std::string &fname,
 
   // --- model
 
-  this->context.load_project_model(actual_fname);
+  if (actual_fname.empty())
+  {
+    // no startup file: blank project with a single empty graph, ready to use
+    this->context.new_project();
+
+    auto config = std::make_shared<GraphConfig>();
+    auto graph = std::make_shared<GraphNode>("graph", config);
+    this->context.project_model->get_graph_manager_ref()->add_graph_node(graph,
+                                                                         "graph");
+  }
+  else
+  {
+    this->context.load_project_model(actual_fname);
+  }
 
   // --- UI
 
@@ -271,7 +284,9 @@ void HesiodApplication::load_project_model_and_ui(const std::string &fname,
   this->project_ui = std::make_unique<ProjectUI>();
 
   this->project_ui->initialize(this->context.project_model.get());
-  this->project_ui->load_ui_state(actual_fname);
+
+  if (!actual_fname.empty())
+    this->project_ui->load_ui_state(actual_fname);
 
   if (this->main_window)
     this->main_window->setCentralWidget(this->project_ui->get_widget());

--- a/Hesiod/src/app/hesiod_application.cpp
+++ b/Hesiod/src/app/hesiod_application.cpp
@@ -253,8 +253,17 @@ void HesiodApplication::load_project_model_and_ui(const std::string &fname,
 
   // --- model
 
-  if (actual_fname.empty())
+  // a missing file must fall back to the blank project too: load_project_model
+  // would return without creating a model and the UI would dereference null
+  const bool blank_startup = actual_fname.empty() || !fs::exists(actual_fname);
+
+  if (blank_startup)
   {
+    if (!actual_fname.empty())
+      Logger::log()->warn("HesiodApplication::load_project_model_and_ui: project "
+                          "file does not exist, starting with a blank project: {}",
+                          actual_fname);
+
     // no startup file: blank project with a single empty graph, ready to use
     this->context.new_project();
 
@@ -285,7 +294,7 @@ void HesiodApplication::load_project_model_and_ui(const std::string &fname,
 
   this->project_ui->initialize(this->context.project_model.get());
 
-  if (!actual_fname.empty())
+  if (!blank_startup)
     this->project_ui->load_ui_state(actual_fname);
 
   if (this->main_window)


### PR DESCRIPTION
As discussed on Discord: opening the application no longer loads `data/default.hsd`. When no project file is chosen (example selector cancelled or disabled, no CLI file) — and on **File > New** — Hesiod now opens a blank project containing a single empty graph, ready to use. The old default graph stays available on the examples page (`_default`).

- `global.default_startup_project_file` now defaults to empty and becomes an opt-in "load this file at startup" setting.
- Existing `hesiod.json` configs carry the old default value (it was persisted on every exit); it is migrated to empty on load so existing installs get the new behaviour too. A custom path set there is untouched.
- The blank path also skips the UI-state load, avoiding a spurious `json_from_file` error in the log.

Tested locally (Linux/NixOS, Wayland): selector "Start New Project" → blank single-graph project; File > New → same; examples page unchanged; Save on the blank project goes to Save-As; `--snapshot`/`--inventory` headless paths unaffected (both always pass or need no filename).