### PR TITLE
Unsaved-changes prompt on quit, close and project-discarding actions

### DIFF
--- a/Hesiod/include/hesiod/app/hesiod_application.hpp
+++ b/Hesiod/include/hesiod/app/hesiod_application.hpp
@@ -47,6 +47,10 @@ public:
 
   void notify(const std::string &msg = "", int timeout = 5000);
 
+  // returns true when the caller may discard the current project (clean,
+  // saved on request, or explicitly discarded); false aborts the action
+  bool confirm_discard_unsaved_changes(const QString &action_title);
+
   // --- Context
   QApplication     &get_qapp();
   AppContext       &get_context();

--- a/Hesiod/src/app/hesiod_application.cpp
+++ b/Hesiod/src/app/hesiod_application.cpp
@@ -221,6 +221,28 @@ void HesiodApplication::cleanup()
     this->context.project_model->cleanup();
 }
 
+bool HesiodApplication::confirm_discard_unsaved_changes(const QString &action_title)
+{
+  if (!this->context.project_model || !this->context.project_model->get_is_dirty())
+    return true;
+
+  QMessageBox::StandardButton reply = QMessageBox::warning(
+      this->main_window,
+      action_title,
+      "The project has unsaved changes.",
+      QMessageBox::Save | QMessageBox::Discard | QMessageBox::Cancel,
+      QMessageBox::Save);
+
+  if (reply == QMessageBox::Save)
+  {
+    this->on_save();
+    // still dirty means the user backed out of the save-as dialog
+    return !this->context.project_model->get_is_dirty();
+  }
+
+  return reply == QMessageBox::Discard;
+}
+
 BlenderStreamer &HesiodApplication::get_blender_streamer()
 {
   return this->blender_streamer;
@@ -485,6 +507,9 @@ void HesiodApplication::on_load()
 {
   Logger::log()->trace("HesiodApplication::on_load");
 
+  if (!this->confirm_discard_unsaved_changes("Load"))
+    return;
+
   fs::path path = this->context.project_model->get_path();
 
   QString load_fname = QFileDialog::getOpenFileName(this->main_window,
@@ -516,6 +541,9 @@ void HesiodApplication::on_open_recent(const std::string &fname)
     return;
   }
 
+  if (!this->confirm_discard_unsaved_changes("Open Recent"))
+    return;
+
   this->load_project_model_and_ui(fname);
   this->add_recent_file(fname);
 }
@@ -523,6 +551,9 @@ void HesiodApplication::on_open_recent(const std::string &fname)
 void HesiodApplication::on_load_ready_made()
 {
   Logger::log()->trace("HesiodApplication::on_load_ready_made");
+
+  if (!this->confirm_discard_unsaved_changes("Open Ready-made Example"))
+    return;
 
   std::string path = this->context.app_settings.global.ready_made_path;
   auto       *ex_dialog = new ExampleSelectorDialog(QString::fromStdString(path));
@@ -540,17 +571,11 @@ void HesiodApplication::on_new()
 {
   Logger::log()->trace("HesiodApplication::on_new");
 
-  QMessageBox::StandardButton reply;
-  reply = QMessageBox::question(nullptr,
-                                "New",
-                                "Clear everything, are you sure?",
-                                QMessageBox::Yes | QMessageBox::No);
+  if (!this->confirm_discard_unsaved_changes("New"))
+    return;
 
-  if (reply == QMessageBox::Yes)
-  {
-    this->cleanup();
-    this->load_project_model_and_ui();
-  }
+  this->cleanup();
+  this->load_project_model_and_ui();
 }
 
 void HesiodApplication::on_online_help()
@@ -581,18 +606,12 @@ void HesiodApplication::on_quit()
 {
   Logger::log()->trace("HesiodApplication::on_quit");
 
-  QMessageBox::StandardButton reply;
-  reply = QMessageBox::question(nullptr,
-                                "Quit",
-                                "Quitting the application, are you sure?",
-                                QMessageBox::Yes | QMessageBox::No);
+  if (!this->confirm_discard_unsaved_changes("Quit"))
+    return;
 
-  if (reply == QMessageBox::Yes)
-  {
-    QApplication::quit();
-    this->main_window->save_geometry();
-    this->context.save_settings();
-  }
+  QApplication::quit();
+  this->main_window->save_geometry();
+  this->context.save_settings();
 }
 
 void HesiodApplication::on_save()

--- a/Hesiod/src/gui/widgets/main_window.cpp
+++ b/Hesiod/src/gui/widgets/main_window.cpp
@@ -23,6 +23,12 @@ void MainWindow::closeEvent(QCloseEvent *event)
 {
   Logger::log()->trace("MainWindow::closeEvent");
 
+  if (!HSD_APP->confirm_discard_unsaved_changes("Quit"))
+  {
+    event->ignore();
+    return;
+  }
+
   this->save_geometry();
   HSD_CTX.save_settings();
 


### PR DESCRIPTION
Adds a single shared guard, `HesiodApplication::confirm_discard_unsaved_changes()`, in front of every action that discards the current project: **Quit**, the **window X button** (which previously discarded unsaved work with no prompt at all), **File > New**, **File > Open**, **Open Recent** and **Open Ready-made Example**.

- Project dirty → modal **Save / Discard / Cancel**. Save runs the normal save flow (Save-As for unnamed projects; backing out of that dialog aborts the action). Cancel keeps the current project (for the X button the close event is ignored).
- Project clean → the action proceeds with no prompt, replacing the previous unconditional "are you sure?" confirmations on Quit and New — dirty-tracking (the `*` in the title bar) already tells us when there is something to lose.

No model changes: the existing `is_dirty` lifecycle (set on change, cleared on save) drives everything.

Tested locally (Linux/NixOS, Wayland): all six entry points clean and dirty, Save-with-Save-As cancel path, Discard, Cancel-on-X.