### PR TITLE
fix(nodes): accept std::filesystem::path in add_filename

### DIFF
--- a/Hesiod/include/hesiod/model/nodes/attributes.hpp
+++ b/Hesiod/include/hesiod/model/nodes/attributes.hpp
@@ -91,7 +91,7 @@ meta::Attribute<std::filesystem::path> &add_filename(
     BaseNode          &node,
     const std::string &key,
     const std::string &label,
-    const std::string &default_path = "",
+    const std::filesystem::path &default_path = {},
     const std::string &filter = "All Files (*.*)",
     bool               is_save = false);
 

--- a/Hesiod/src/model/nodes/attributes.cpp
+++ b/Hesiod/src/model/nodes/attributes.cpp
@@ -183,7 +183,7 @@ meta::Attribute<int> &add_enum(BaseNode                         &node,
 meta::Attribute<std::filesystem::path> &add_filename(BaseNode          &node,
                                                      const std::string &key,
                                                      const std::string &label,
-                                                     const std::string &default_path,
+                                                     const std::filesystem::path &default_path,
                                                      const std::string &filter,
                                                      bool               is_save)
 {


### PR DESCRIPTION
`dev` does not compile on Windows/MSVC. Fourteen node files pass a `std::filesystem::path` to `add_filename()`, whose default parameter is `const std::string&`.

This compiles on POSIX only by accident: `std::filesystem::path::operator string_type()` yields `std::string` there, so the conversion exists. On Windows the same operator yields `std::wstring`, there is no conversion to `std::string`, and every one of those call sites fails.

Widening the parameter to `const std::filesystem::path&` converts identically on both platforms and matches the attribute's own value type, so no call site changes.

Verified building `dev` with Qt 6.10.3 / MSVC 2022 / Ninja.

Note: one other change is needed for a clean MSVC build, in the QTerrainRenderer submodule — `shadow_map_lit_pass.frag` is a 17,457-byte raw string literal and MSVC caps string literals at 16,380 bytes. I can send that to the QTerrainRenderer repo separately if useful.