### PR TITLE
feat(gui): opt the node settings panel into the meta_qt design layer

### DIFF
--- a/Hesiod/include/hesiod/app/app_settings.hpp
+++ b/Hesiod/include/hesiod/app/app_settings.hpp
@@ -88,6 +88,20 @@ struct AppSettings
     bool enable_heightmapper_widget = true;
     bool enable_tool_tips = true;
     bool enable_example_selector_at_startup = true;
+
+    // Node properties panel look. Both are names resolved at runtime, not
+    // enums, so registering a new design or colourway does not mean editing
+    // this struct.
+    //
+    // A design name with nothing registered against it (e.g. "stock") makes
+    // every row fall back to Meta's stock renderer, which is how the two looks
+    // are A/B compared without a rebuild.
+    //
+    // Applied at panel construction. Changing either takes effect on restart --
+    // see meta_qt/ui/theme.hpp for why live re-theming is deliberately not
+    // supported yet.
+    std::string properties_panel_design = "industrial";
+    std::string properties_panel_theme = "industrial-dark";
   } interface;
 
   struct NodeEditor

--- a/Hesiod/src/app/app_settings.cpp
+++ b/Hesiod/src/app/app_settings.cpp
@@ -145,6 +145,12 @@ void AppSettings::json_from(nlohmann::json const &json)
   json_safe_get(json,
                 "interface.enable_example_selector_at_startup",
                 interface.enable_example_selector_at_startup);
+  json_safe_get(json,
+                "interface.properties_panel_design",
+                interface.properties_panel_design);
+  json_safe_get(json,
+                "interface.properties_panel_theme",
+                interface.properties_panel_theme);
 
   // OpenCL device
   {
@@ -256,6 +262,8 @@ nlohmann::json AppSettings::json_to() const
   json["interface.enable_tool_tips"] = interface.enable_tool_tips;
   json["interface.enable_example_selector_at_startup"] =
       interface.enable_example_selector_at_startup;
+  json["interface.properties_panel_design"] = interface.properties_panel_design;
+  json["interface.properties_panel_theme"] = interface.properties_panel_theme;
 
   json["node_editor.gpu_device_name"] = node_editor.gpu_device_name;
   json["node_editor.default_resolution"] = node_editor.default_resolution;

--- a/Hesiod/src/gui/widgets/node_attributes_widget.cpp
+++ b/Hesiod/src/gui/widgets/node_attributes_widget.cpp
@@ -11,6 +11,9 @@
 #include <QToolButton>
 
 #include "meta_qt/container_group_widget.hpp"
+#include "meta_qt/designs/industrial/industrial.hpp"
+#include "meta_qt/ui/design_registry.hpp"
+#include "meta_qt/ui/theme.hpp"
 #include "meta_qt/widgets/collapsible_section.hpp"
 
 #include "hesiod/app/hesiod_application.hpp"
@@ -21,6 +24,59 @@
 
 namespace hesiod
 {
+
+namespace
+{
+
+/** @brief Look up an attribute's default value from a node's initial state.
+ *
+ * The panel needs this because "modified" means `|value - default| > 1e-4`,
+ * not "changed since the panel opened", and a Meta attribute does not carry
+ * its own default. BaseNode captures one in finalize_attributes().
+ *
+ * The initial state is a ContainerGroup snapshot:
+ *   { "current": name, "containers": { <container>: { <attr>: { "value": ... } } } }
+ *
+ * Returns an empty std::any for anything it cannot resolve -- an unknown
+ * default is reported as *not* modified, since a panel that paints every row
+ * as modified is worse than one that paints none.
+ */
+std::any lookup_default(const nlohmann::json    &initial_state,
+                        const std::string       &container_name,
+                        const std::string       &key,
+                        const std::type_index   &type)
+{
+  if (!initial_state.contains("containers")) return {};
+
+  const auto &containers = initial_state["containers"];
+  if (!containers.contains(container_name)) return {};
+
+  const auto &container = containers[container_name];
+  if (!container.contains(key)) return {};
+
+  const auto &entry = container[key];
+  if (!entry.contains("value")) return {};
+
+  const auto &value = entry["value"];
+
+  try
+  {
+    // Only the types the design actually renders need converting; anything
+    // else falls through to "unknown", which is harmless.
+    if (type == std::type_index(typeid(float))) return value.get<float>();
+    if (type == std::type_index(typeid(bool))) return value.get<bool>();
+    if (type == std::type_index(typeid(int))) return value.get<int>();
+  }
+  catch (const nlohmann::json::exception &)
+  {
+    // A snapshot whose shape disagrees with the live attribute is a host bug,
+    // not a reason to refuse to draw the row.
+  }
+
+  return {};
+}
+
+} // namespace
 
 NodeAttributesWidget::NodeAttributesWidget(std::weak_ptr<GraphNode>  p_graph_node,
                                            const std::string        &node_id,
@@ -316,9 +372,48 @@ void NodeAttributesWidget::setup_layout()
 
   // --- Meta ContainerGroupWidget
 
+  // Designs register once per process; calling this unconditionally is cheap
+  // and keeps the registration next to the only thing that consumes it.
+  meta::qt::industrial::register_design();
+
+  const AppSettings &settings = HSD_CTX.app_settings;
+  const std::string  design = settings.interface.properties_panel_design;
+  const meta::qt::Theme &theme = meta::qt::ThemeRegistry::instance().get(
+      settings.interface.properties_panel_theme);
+
+  meta::qt::RowContext row_ctx;
+  row_ctx.theme = &theme;
+
+  // Captures by value: the row renderer outlives this function, and the widget
+  // owns the node only weakly.
+  const nlohmann::json initial_state = p_node->get_initial_meta_state();
+  const std::string    container_name = p_node->get_meta_group()
+                                         .current_container_name()
+                                         .value_or(std::string{});
+
+  row_ctx.default_value = [initial_state, container_name, this](
+                              const std::string &key) -> std::any
+  {
+    auto gno = this->p_graph_node.lock();
+    if (!gno) return {};
+
+    BaseNode *p_current = gno->get_node_ref_by_id<BaseNode>(this->node_id);
+    if (!p_current) return {};
+
+    auto *p_attr = p_current->get_meta_group().current().find(key);
+    if (!p_attr) return {};
+
+    return lookup_default(initial_state, container_name, key, p_attr->type());
+  };
+
   auto options = meta::qt::ContainerRenderOptions{
       .category_policy = meta::qt::CategoryPolicy::CP_MERGED,
       .root_category_name = std::string{}};
+
+  // An unregistered design name resolves nothing and every row falls back to
+  // the stock renderer, so "stock" is a working value here rather than a error.
+  options.row_renderer = [design, row_ctx](meta::AbstractAttribute *p_attr)
+  { return meta::qt::render_row(p_attr, design, row_ctx); };
 
   this->meta_widget = meta::qt::render(p_node->get_meta_group(),
                                        options,


### PR DESCRIPTION
> **Draft — depends on ottolink-dev/Meta#45.** The submodule bump here points at that branch, so this will not resolve until it lands. Opening now so the two can be read together.

Host-side counterpart to the `meta_qt` design layer. Small on purpose: ~60 lines of integration, no new widgets here.

## What it does

Selects a widget design and colourway for the node attributes panel by name, resolved at construction:

```
interface.properties_panel_design  = "industrial"
interface.properties_panel_theme   = "industrial-dark"
```

Strings rather than enums, so registering a new design doesn't mean editing `AppSettings`.

**`"stock"` is a working value.** A design name with nothing registered against it resolves no factories, every row falls back to `meta::qt::render()`, and the panel is identical to today's. Comparing the two looks is a settings change, not a rebuild — which is also how I'd suggest reviewing it.

New keys are read with `json_safe_get`, so existing configs keep the compiled default rather than being migrated.

## The defaults bridge

The design layer needs each attribute's default to colour modified-vs-default text, where "modified" is `|value - default| > 1e-4` rather than "changed since the panel opened". A Meta attribute doesn't carry its default, but `BaseNode::finalize_attributes()` already snapshots one, so the provider reads that.

Anything it can't resolve reports *not* modified — a panel painting every row as modified is worse than one painting none.

## Status

Verified on Qt 6.10.3 / MSVC 2022 against `data/bootstraps/island.hsd`. Float sliders and bool toggles render through the new layer (~72% of rows); `SliderInt`, `LinkedSliders`, combos, range bars and the gradient editor all fall back to stock and are unaffected.

Checked by hand: drag tracking, glide-on-double-click-reset, typed commit, wheel-ignored-unless-focused, toggle animation, and values surviving a node reselect.

Section chrome is still stock, so the panel currently reads as two designs side by side. That's the next slice, along with `SliderInt` and `EnumComboBox`.