### PR TITLE
fix(nodes): accept std::filesystem::path in add_filename

### DIFF
--- a/Hesiod/include/hesiod/model/nodes/attributes.hpp
+++ b/Hesiod/include/hesiod/model/nodes/attributes.hpp
@@ -91,7 +91,7 @@ meta::Attribute<std::filesystem::path> &add_filename(
     BaseNode          &node,
     const std::string &key,
     const std::string &label,
-    const std::string &default_path = "",
+    const std::filesystem::path &default_path = {},
     const std::string &filter = "All Files (*.*)",
     bool               is_save = false);
 

--- a/Hesiod/src/model/nodes/attributes.cpp
+++ b/Hesiod/src/model/nodes/attributes.cpp
@@ -183,7 +183,7 @@ meta::Attribute<int> &add_enum(BaseNode                         &node,
 meta::Attribute<std::filesystem::path> &add_filename(BaseNode          &node,
                                                      const std::string &key,
                                                      const std::string &label,
-                                                     const std::string &default_path,
+                                                     const std::filesystem::path &default_path,
                                                      const std::string &filter,
                                                      bool               is_save)
 {


### PR DESCRIPTION
`dev` doesnt build on Windows/MSVC at the moment.

`add_filename()` takes its default as `const std::string&`, but 14 node files pass a `std::filesystem::path`. That works on Linux by accident, because `path::operator string_type()` gives you a `std::string` there. On Windows the same operator gives `std::wstring`, so theres no conversion and all 14 call sites fail to compile.

Changed the parameter to `const std::filesystem::path&` — converts the same on both platforms and matches the attribute's own type anyway, so no call sites need touching.

Built `dev` with Qt 6.10.3 / MSVC 2022 / Ninja to check.

One other thing is needed for a clean MSVC build but its in QTerrainRenderer, not here — `shadow_map_lit_pass.frag` is a 17457 byte raw string literal and MSVC caps them at 16380. Can send that over separately if useful.