### PR TITLE
feat(gui): opt the node settings panel into the meta_qt design layer

### DIFF
--- a/Hesiod/include/hesiod/app/app_settings.hpp
+++ b/Hesiod/include/hesiod/app/app_settings.hpp
@@ -101,8 +101,11 @@ struct AppSettings
     // Applied at panel construction. Changing either takes effect on restart --
     // see meta_qt/ui/theme.hpp for why live re-theming is deliberately not
     // supported yet.
+    // "palette" derives every colour from the application palette, so the
+    // panel follows the app's colour scheme rather than imposing its own.
+    // "industrial-dark" pins the reference colourway instead.
     std::string properties_panel_design = "industrial";
-    std::string properties_panel_theme = "industrial-dark";
+    std::string properties_panel_theme = "palette";
   } interface;
 
   struct NodeEditor

--- a/Hesiod/include/hesiod/app/app_settings.hpp
+++ b/Hesiod/include/hesiod/app/app_settings.hpp
@@ -95,8 +95,9 @@ struct AppSettings
     //
     // "industrial" and "stock" are peer designs, so selecting "stock" gives
     // the unmodified Qt look -- that is how the two are A/B compared without a
-    // rebuild. A widget type "industrial" has not covered yet resolves through
-    // stock via the design's fallback chain.
+    // rebuild. A widget type "industrial" does not cover yet resolves through
+    // stock via the design's fallback chain. An unregistered name falls back
+    // to stock with a warning rather than drawing an empty panel.
     //
     // Applied at panel construction. Changing either takes effect on restart --
     // see meta_qt/ui/theme.hpp for why live re-theming is deliberately not

--- a/Hesiod/include/hesiod/app/app_settings.hpp
+++ b/Hesiod/include/hesiod/app/app_settings.hpp
@@ -88,6 +88,21 @@ struct AppSettings
     bool enable_heightmapper_widget = true;
     bool enable_tool_tips = true;
     bool enable_example_selector_at_startup = true;
+
+    // Node properties panel look. Both are names resolved at runtime, not
+    // enums, so registering a new design or colourway does not mean editing
+    // this struct.
+    //
+    // "industrial" and "stock" are peer designs, so selecting "stock" gives
+    // the unmodified Qt look -- that is how the two are A/B compared without a
+    // rebuild. A widget type "industrial" has not covered yet resolves through
+    // stock via the design's fallback chain.
+    //
+    // Applied at panel construction. Changing either takes effect on restart --
+    // see meta_qt/ui/theme.hpp for why live re-theming is deliberately not
+    // supported yet.
+    std::string properties_panel_design = "industrial";
+    std::string properties_panel_theme = "industrial-dark";
   } interface;
 
   struct NodeEditor

--- a/Hesiod/include/hesiod/gui/widgets/properties_panel_design.hpp
+++ b/Hesiod/include/hesiod/gui/widgets/properties_panel_design.hpp
@@ -1,0 +1,45 @@
+/* Copyright (c) 2025 Otto Link. Distributed under the terms of the GNU General
+ * Public License. The full license is in the file LICENSE, distributed with
+ * this software. */
+#pragma once
+#include <string>
+
+namespace meta::qt
+{
+struct Theme;
+}
+
+namespace hesiod
+{
+
+/** @brief The properties panel's design, resolved once and validated.
+ *
+ * Both the settings pane and the attributes widget need to know which design
+ * is running: one to decide its scrollbar and margins, the other to pick the
+ * row renderer and whether to wrap loose attributes in a root section. Asking
+ * the settings separately in each let the two disagree, so the panel ended up
+ * with industrial chrome around stock rows.
+ */
+struct PropertiesPanelDesign
+{
+  /// Design name that is actually registered, never the raw settings string.
+  std::string design;
+
+  /// Theme the design draws with.
+  const meta::qt::Theme *theme = nullptr;
+
+  /// True when the design brings its own panel chrome and section cards.
+  bool has_own_chrome = false;
+};
+
+/** @brief Resolve the panel design from app settings.
+ *
+ * Registers the built-in designs on first call, then checks the configured
+ * name against the registry. An unknown name falls back to stock with a
+ * warning: DesignRegistry only follows explicit fallbacks and otherwise
+ * returns nullptr, so a typo in hesiod.json would otherwise drop every row and
+ * leave an empty panel with nothing to explain it.
+ */
+const PropertiesPanelDesign &properties_panel_design();
+
+} // namespace hesiod

--- a/Hesiod/include/hesiod/model/nodes/base_node.hpp
+++ b/Hesiod/include/hesiod/model/nodes/base_node.hpp
@@ -164,7 +164,7 @@ public:
 private:
   // --- Members ---
   std::unique_ptr<meta::ContainerGroup> meta_group; // attribute storage
-  std::string                           current_category;
+  std::string                           current_category = "Main Parameters";
 
   // container state captured at finalize time; toolbar "Reset Settings" restores it
   nlohmann::json initial_meta_state;

--- a/Hesiod/include/hesiod/model/nodes/base_node.hpp
+++ b/Hesiod/include/hesiod/model/nodes/base_node.hpp
@@ -1,9 +1,11 @@
 /* Copyright (c) 2023 Otto Link. Distributed under the terms of the GNU General Public
    License. The full license is in the file LICENSE, distributed with this software. */
 #pragma once
+#include <any>
 #include <array>
 #include <chrono>
 #include <functional>
+#include <map>
 #include <stdexcept>
 #include <tuple>
 #include <utility>
@@ -143,6 +145,16 @@ public:
     return this->initial_meta_state;
   }
 
+  /** @brief Default value of an attribute, or an empty any if there is none.
+   *
+   * Taken straight off the attribute at finalize time, so it covers every type
+   * the node can hold rather than the handful that survive a round trip
+   * through json. The properties panel uses it to decide what counts as
+   * modified.
+   */
+  std::any get_initial_default(const std::string &container_name,
+                               const std::string &key) const;
+
   void reseed(bool backward);
 
   // --- Callbacks - "signals" equivalent
@@ -156,6 +168,9 @@ private:
 
   // container state captured at finalize time; toolbar "Reset Settings" restores it
   nlohmann::json initial_meta_state;
+
+  // the same snapshot as live values, keyed by container then attribute name
+  std::map<std::string, std::map<std::string, std::any>> initial_meta_defaults;
 
   std::string                         category;
   std::string                         comment;

--- a/Hesiod/src/app/app_settings.cpp
+++ b/Hesiod/src/app/app_settings.cpp
@@ -145,6 +145,12 @@ void AppSettings::json_from(nlohmann::json const &json)
   json_safe_get(json,
                 "interface.enable_example_selector_at_startup",
                 interface.enable_example_selector_at_startup);
+  json_safe_get(json,
+                "interface.properties_panel_design",
+                interface.properties_panel_design);
+  json_safe_get(json,
+                "interface.properties_panel_theme",
+                interface.properties_panel_theme);
 
   // OpenCL device
   {
@@ -263,6 +269,8 @@ nlohmann::json AppSettings::json_to() const
   json["interface.enable_tool_tips"] = interface.enable_tool_tips;
   json["interface.enable_example_selector_at_startup"] =
       interface.enable_example_selector_at_startup;
+  json["interface.properties_panel_design"] = interface.properties_panel_design;
+  json["interface.properties_panel_theme"] = interface.properties_panel_theme;
 
   json["node_editor.gpu_device_name"] = node_editor.gpu_device_name;
   json["node_editor.default_resolution"] = node_editor.default_resolution;

--- a/Hesiod/src/gui/widgets/node_attributes_widget.cpp
+++ b/Hesiod/src/gui/widgets/node_attributes_widget.cpp
@@ -13,6 +13,7 @@
 
 #include "meta_qt/container_group_widget.hpp"
 #include "meta_qt/designs/industrial/industrial.hpp"
+#include "meta_qt/designs/industrial/section.hpp"
 #include "meta_qt/ui/design_registry.hpp"
 #include "meta_qt/ui/theme.hpp"
 #include "meta_qt/widgets/collapsible_section.hpp"
@@ -75,6 +76,20 @@ std::any lookup_default(const nlohmann::json    &initial_state,
   }
 
   return {};
+}
+
+/// True when any attribute declares a ui.category, i.e. the node builds its own
+/// sections and does not need a root one wrapped around them.
+bool has_categorised_attributes(BaseNode &node)
+{
+  auto &container = node.get_meta_group().current();
+
+  for (const auto &key : container.insertion_order())
+    if (const auto *p_attr = container.find(key))
+      if (!meta::common::category(*p_attr).empty())
+        return true;
+
+  return false;
 }
 
 /** @brief Register a "palette" theme derived from Hesiod's own colours.
@@ -449,12 +464,28 @@ void NodeAttributesWidget::setup_layout()
 
   auto options = meta::qt::ContainerRenderOptions{
       .category_policy = meta::qt::CategoryPolicy::CP_MERGED,
-      .root_category_name = std::string{}};
+      // Uncategorised attributes would otherwise sit bare under the toolbar
+      // with no card behind them, which on a node with a single parameter looks
+      // like an unfinished panel rather than a small one.
+      //
+      // Only when the node has no categories of its own, though: adding a root
+      // section to a node that already has some wraps every real section in a
+      // second card, which reads as nested boxes rather than grouping.
+      .root_category_name = (design == meta::qt::industrial::kDesignName &&
+                             !has_categorised_attributes(*p_node))
+                                ? std::string{"Parameters"}
+                                : std::string{}};
 
   // An unregistered design name resolves nothing and every row falls back to
   // the stock renderer, so "stock" is a working value here rather than a error.
   options.row_renderer = [design, row_ctx](meta::AbstractAttribute *p_attr)
   { return meta::qt::render_row(p_attr, design, row_ctx); };
+
+  // Section chrome is not bound to an attribute, so it cannot go through the
+  // design registry. Only the industrial design supplies one; any other design
+  // keeps the stock section.
+  if (design == meta::qt::industrial::kDesignName)
+    options.section_factory = meta::qt::industrial::make_section_factory(theme);
 
   this->meta_widget = meta::qt::render(p_node->get_meta_group(),
                                        options,

--- a/Hesiod/src/gui/widgets/node_attributes_widget.cpp
+++ b/Hesiod/src/gui/widgets/node_attributes_widget.cpp
@@ -12,8 +12,6 @@
 #include <QToolButton>
 
 #include "meta_qt/container_group_widget.hpp"
-#include "meta_qt/designs/industrial/industrial.hpp"
-#include "meta_qt/designs/industrial/section.hpp"
 #include "meta_qt/ui/design_registry.hpp"
 #include "meta_qt/ui/theme.hpp"
 #include "meta_qt/widgets/collapsible_section.hpp"
@@ -21,6 +19,7 @@
 #include "hesiod/app/hesiod_application.hpp"
 #include "hesiod/gui/widgets/documentation_popup.hpp"
 #include "hesiod/gui/widgets/node_attributes_widget.hpp"
+#include "hesiod/gui/widgets/properties_panel_design.hpp"
 #include "hesiod/logger.hpp"
 #include "hesiod/model/nodes/base_node.hpp"
 
@@ -30,105 +29,28 @@ namespace hesiod
 namespace
 {
 
-/** @brief Look up an attribute's default value from a node's initial state.
+/** @brief True when any attribute anywhere in the group declares a ui.category.
  *
- * The panel needs this because "modified" means `|value - default| > 1e-4`,
- * not "changed since the panel opened", and a Meta attribute does not carry
- * its own default. BaseNode captures one in finalize_attributes().
- *
- * The initial state is a ContainerGroup snapshot:
- *   { "current": name, "containers": { <container>: { <attr>: { "value": ... } } } }
- *
- * Returns an empty std::any for anything it cannot resolve -- an unknown
- * default is reported as *not* modified, since a panel that paints every row
- * as modified is worse than one that paints none.
+ * A node that builds its own sections does not want a root one wrapped around
+ * them. Every container is checked, not just the current one, because the root
+ * category is decided once for the whole group: reading only the current
+ * container meant switching to a container whose attributes are all
+ * uncategorised put a second card around the sections of the others.
  */
-std::any lookup_default(const nlohmann::json    &initial_state,
-                        const std::string       &container_name,
-                        const std::string       &key,
-                        const std::type_index   &type)
-{
-  if (!initial_state.contains("containers")) return {};
-
-  const auto &containers = initial_state["containers"];
-  if (!containers.contains(container_name)) return {};
-
-  const auto &container = containers[container_name];
-  if (!container.contains(key)) return {};
-
-  const auto &entry = container[key];
-  if (!entry.contains("value")) return {};
-
-  const auto &value = entry["value"];
-
-  try
-  {
-    // Only the types the design actually renders need converting; anything
-    // else falls through to "unknown", which is harmless.
-    if (type == std::type_index(typeid(float))) return value.get<float>();
-    if (type == std::type_index(typeid(bool))) return value.get<bool>();
-    if (type == std::type_index(typeid(int))) return value.get<int>();
-  }
-  catch (const nlohmann::json::exception &)
-  {
-    // A snapshot whose shape disagrees with the live attribute is a host bug,
-    // not a reason to refuse to draw the row.
-  }
-
-  return {};
-}
-
-/// True when any attribute declares a ui.category, i.e. the node builds its own
-/// sections and does not need a root one wrapped around them.
 bool has_categorised_attributes(BaseNode &node)
 {
-  auto &container = node.get_meta_group().current();
+  for (const auto &[name, p_container] : node.get_meta_group().containers())
+  {
+    if (!p_container)
+      continue;
 
-  for (const auto &key : container.insertion_order())
-    if (const auto *p_attr = container.find(key))
-      if (!meta::common::category(*p_attr).empty())
-        return true;
+    for (const auto &key : p_container->insertion_order())
+      if (const auto *p_attr = p_container->find(key))
+        if (!meta::common::category(*p_attr).empty())
+          return true;
+  }
 
   return false;
-}
-
-/** @brief Register a "palette" theme derived from Hesiod's own colours.
- *
- * Meta derives the base theme from a QPalette so the design fits whatever
- * colour scheme the host runs. Hesiod never sets an application palette
- * though: it keeps its colours in AppSettings::Colors and applies them through
- * per-widget stylesheets. Left alone, meta_qt would therefore derive from the
- * *system* palette and the panel would follow Windows rather than Hesiod.
- *
- * So map the app settings onto a palette and hand that over. Meta does the
- * derivation; Hesiod supplies the colours, which keeps the split intact.
- *
- * Note this makes the rails take the app accent (blue by default) rather than
- * the reference orange. Set interface.properties_panel_theme to
- * "industrial-dark" to pin the reference colourway instead.
- */
-void register_hesiod_palette_theme()
-{
-  static bool done = false;
-  if (done) return;
-  done = true;
-
-  const AppSettings::Colors &c = HSD_CTX.app_settings.colors;
-
-  QPalette palette = QApplication::palette();
-  palette.setColor(QPalette::Window, c.bg_primary);
-  palette.setColor(QPalette::Base, c.bg_deep);
-  palette.setColor(QPalette::Text, c.text_primary);
-  palette.setColor(QPalette::WindowText, c.text_primary);
-  palette.setColor(QPalette::BrightText, c.accent_bw);
-  palette.setColor(QPalette::Mid, c.border);
-  palette.setColor(QPalette::Light, c.text_primary);
-  palette.setColor(QPalette::Highlight, c.accent);
-  palette.setColor(QPalette::Disabled, QPalette::Text, c.text_disabled);
-
-  // Registering under the same name replaces the system-derived default.
-  meta::qt::ThemeRegistry::instance().add(
-      meta::qt::Theme::from_palette(palette, meta::qt::ThemeRegistry::kPaletteTheme));
 }
 
 } // namespace
@@ -427,28 +349,20 @@ void NodeAttributesWidget::setup_layout()
 
   // --- Meta ContainerGroupWidget
 
-  // Designs register once per process; calling this unconditionally is cheap
-  // and keeps the registration next to the only thing that consumes it.
-  meta::qt::industrial::register_design();
-  register_hesiod_palette_theme();
+  // Registers the designs on first call and validates the configured name.
 
-  const AppSettings &settings = HSD_CTX.app_settings;
-  const std::string  design = settings.interface.properties_panel_design;
-  const meta::qt::Theme &theme = meta::qt::ThemeRegistry::instance().get(
-      settings.interface.properties_panel_theme);
+  const PropertiesPanelDesign &panel = properties_panel_design();
 
   meta::qt::RowContext row_ctx;
-  row_ctx.theme = &theme;
+  row_ctx.theme = panel.theme;
 
-  // Captures by value: the row renderer outlives this function, and the widget
-  // owns the node only weakly.
-  const nlohmann::json initial_state = p_node->get_initial_meta_state();
-  const std::string    container_name = p_node->get_meta_group()
-                                         .current_container_name()
-                                         .value_or(std::string{});
-
-  row_ctx.default_value = [initial_state, container_name, this](
-                              const std::string &key) -> std::any
+  // Only `this` is captured. The defaults live on the node, so reading them
+  // through the live node keeps the lookup correct after the node switches
+  // container: capturing the container name at build time meant a CoherentNoise
+  // switched to Ridged still resolved its defaults against the fbm container,
+  // and nothing ever showed as modified. It also avoids copying the whole
+  // initial state into the closure, which on a Brush node is a heightmap.
+  row_ctx.default_value = [this](const std::string &key) -> std::any
   {
     auto gno = this->p_graph_node.lock();
     if (!gno) return {};
@@ -456,13 +370,16 @@ void NodeAttributesWidget::setup_layout()
     BaseNode *p_current = gno->get_node_ref_by_id<BaseNode>(this->node_id);
     if (!p_current) return {};
 
-    auto *p_attr = p_current->get_meta_group().current().find(key);
-    if (!p_attr) return {};
+    const std::string container_name = p_current->get_meta_group()
+                                           .current_container_name()
+                                           .value_or(std::string{});
 
-    return lookup_default(initial_state, container_name, key, p_attr->type());
+    return p_current->get_initial_default(container_name, key);
   };
 
   auto options = meta::qt::ContainerRenderOptions{
+      .design = panel.design,
+      .row_context = row_ctx,
       .category_policy = meta::qt::CategoryPolicy::CP_MERGED,
       // Uncategorised attributes would otherwise sit bare under the toolbar
       // with no card behind them, which on a node with a single parameter looks
@@ -471,21 +388,10 @@ void NodeAttributesWidget::setup_layout()
       // Only when the node has no categories of its own, though: adding a root
       // section to a node that already has some wraps every real section in a
       // second card, which reads as nested boxes rather than grouping.
-      .root_category_name = (design == meta::qt::industrial::kDesignName &&
+      .root_category_name = (panel.has_own_chrome &&
                              !has_categorised_attributes(*p_node))
                                 ? std::string{"Parameters"}
                                 : std::string{}};
-
-  // An unregistered design name resolves nothing and every row falls back to
-  // the stock renderer, so "stock" is a working value here rather than a error.
-  options.row_renderer = [design, row_ctx](meta::AbstractAttribute *p_attr)
-  { return meta::qt::render_row(p_attr, design, row_ctx); };
-
-  // Section chrome is not bound to an attribute, so it cannot go through the
-  // design registry. Only the industrial design supplies one; any other design
-  // keeps the stock section.
-  if (design == meta::qt::industrial::kDesignName)
-    options.section_factory = meta::qt::industrial::make_section_factory(theme);
 
   this->meta_widget = meta::qt::render(p_node->get_meta_group(),
                                        options,

--- a/Hesiod/src/gui/widgets/node_attributes_widget.cpp
+++ b/Hesiod/src/gui/widgets/node_attributes_widget.cpp
@@ -11,6 +11,9 @@
 #include <QToolButton>
 
 #include "meta_qt/container_group_widget.hpp"
+#include "meta_qt/designs/industrial/industrial.hpp"
+#include "meta_qt/ui/design_registry.hpp"
+#include "meta_qt/ui/theme.hpp"
 #include "meta_qt/widgets/collapsible_section.hpp"
 
 #include "hesiod/app/hesiod_application.hpp"
@@ -21,6 +24,59 @@
 
 namespace hesiod
 {
+
+namespace
+{
+
+/** @brief Look up an attribute's default value from a node's initial state.
+ *
+ * The panel needs this because "modified" means `|value - default| > 1e-4`,
+ * not "changed since the panel opened", and a Meta attribute does not carry
+ * its own default. BaseNode captures one in finalize_attributes().
+ *
+ * The initial state is a ContainerGroup snapshot:
+ *   { "current": name, "containers": { <container>: { <attr>: { "value": ... } } } }
+ *
+ * Returns an empty std::any for anything it cannot resolve -- an unknown
+ * default is reported as *not* modified, since a panel that paints every row
+ * as modified is worse than one that paints none.
+ */
+std::any lookup_default(const nlohmann::json    &initial_state,
+                        const std::string       &container_name,
+                        const std::string       &key,
+                        const std::type_index   &type)
+{
+  if (!initial_state.contains("containers")) return {};
+
+  const auto &containers = initial_state["containers"];
+  if (!containers.contains(container_name)) return {};
+
+  const auto &container = containers[container_name];
+  if (!container.contains(key)) return {};
+
+  const auto &entry = container[key];
+  if (!entry.contains("value")) return {};
+
+  const auto &value = entry["value"];
+
+  try
+  {
+    // Only the types the design actually renders need converting; anything
+    // else falls through to "unknown", which is harmless.
+    if (type == std::type_index(typeid(float))) return value.get<float>();
+    if (type == std::type_index(typeid(bool))) return value.get<bool>();
+    if (type == std::type_index(typeid(int))) return value.get<int>();
+  }
+  catch (const nlohmann::json::exception &)
+  {
+    // A snapshot whose shape disagrees with the live attribute is a host bug,
+    // not a reason to refuse to draw the row.
+  }
+
+  return {};
+}
+
+} // namespace
 
 NodeAttributesWidget::NodeAttributesWidget(std::weak_ptr<GraphNode>  p_graph_node,
                                            const std::string        &node_id,
@@ -316,9 +372,48 @@ void NodeAttributesWidget::setup_layout()
 
   // --- Meta ContainerGroupWidget
 
+  // Designs register once per process; calling this unconditionally is cheap
+  // and keeps the registration next to the only thing that consumes it.
+  meta::qt::industrial::register_design();
+
+  const AppSettings &settings = HSD_CTX.app_settings;
+  const std::string  design = settings.interface.properties_panel_design;
+  const meta::qt::Theme &theme = meta::qt::ThemeRegistry::instance().get(
+      settings.interface.properties_panel_theme);
+
+  meta::qt::RowContext row_ctx;
+  row_ctx.theme = &theme;
+
+  // Captures by value: the row renderer outlives this function, and the widget
+  // owns the node only weakly.
+  const nlohmann::json initial_state = p_node->get_initial_meta_state();
+  const std::string    container_name = p_node->get_meta_group()
+                                         .current_container_name()
+                                         .value_or(std::string{});
+
+  row_ctx.default_value = [initial_state, container_name, this](
+                              const std::string &key) -> std::any
+  {
+    auto gno = this->p_graph_node.lock();
+    if (!gno) return {};
+
+    BaseNode *p_current = gno->get_node_ref_by_id<BaseNode>(this->node_id);
+    if (!p_current) return {};
+
+    auto *p_attr = p_current->get_meta_group().current().find(key);
+    if (!p_attr) return {};
+
+    return lookup_default(initial_state, container_name, key, p_attr->type());
+  };
+
   auto options = meta::qt::ContainerRenderOptions{
       .category_policy = meta::qt::CategoryPolicy::CP_MERGED,
       .root_category_name = std::string{}};
+
+  // An unregistered design name resolves nothing and every row falls back to
+  // the stock renderer, so "stock" is a working value here rather than a error.
+  options.row_renderer = [design, row_ctx](meta::AbstractAttribute *p_attr)
+  { return meta::qt::render_row(p_attr, design, row_ctx); };
 
   this->meta_widget = meta::qt::render(p_node->get_meta_group(),
                                        options,

--- a/Hesiod/src/gui/widgets/node_attributes_widget.cpp
+++ b/Hesiod/src/gui/widgets/node_attributes_widget.cpp
@@ -3,6 +3,7 @@
  * this software. */
 #include <fstream>
 
+#include <QApplication>
 #include <QDesktopServices>
 #include <QFileDialog>
 #include <QLayout>
@@ -74,6 +75,45 @@ std::any lookup_default(const nlohmann::json    &initial_state,
   }
 
   return {};
+}
+
+/** @brief Register a "palette" theme derived from Hesiod's own colours.
+ *
+ * Meta derives the base theme from a QPalette so the design fits whatever
+ * colour scheme the host runs. Hesiod never sets an application palette
+ * though: it keeps its colours in AppSettings::Colors and applies them through
+ * per-widget stylesheets. Left alone, meta_qt would therefore derive from the
+ * *system* palette and the panel would follow Windows rather than Hesiod.
+ *
+ * So map the app settings onto a palette and hand that over. Meta does the
+ * derivation; Hesiod supplies the colours, which keeps the split intact.
+ *
+ * Note this makes the rails take the app accent (blue by default) rather than
+ * the reference orange. Set interface.properties_panel_theme to
+ * "industrial-dark" to pin the reference colourway instead.
+ */
+void register_hesiod_palette_theme()
+{
+  static bool done = false;
+  if (done) return;
+  done = true;
+
+  const AppSettings::Colors &c = HSD_CTX.app_settings.colors;
+
+  QPalette palette = QApplication::palette();
+  palette.setColor(QPalette::Window, c.bg_primary);
+  palette.setColor(QPalette::Base, c.bg_deep);
+  palette.setColor(QPalette::Text, c.text_primary);
+  palette.setColor(QPalette::WindowText, c.text_primary);
+  palette.setColor(QPalette::BrightText, c.accent_bw);
+  palette.setColor(QPalette::Mid, c.border);
+  palette.setColor(QPalette::Light, c.text_primary);
+  palette.setColor(QPalette::Highlight, c.accent);
+  palette.setColor(QPalette::Disabled, QPalette::Text, c.text_disabled);
+
+  // Registering under the same name replaces the system-derived default.
+  meta::qt::ThemeRegistry::instance().add(
+      meta::qt::Theme::from_palette(palette, meta::qt::ThemeRegistry::kPaletteTheme));
 }
 
 } // namespace
@@ -375,6 +415,7 @@ void NodeAttributesWidget::setup_layout()
   // Designs register once per process; calling this unconditionally is cheap
   // and keeps the registration next to the only thing that consumes it.
   meta::qt::industrial::register_design();
+  register_hesiod_palette_theme();
 
   const AppSettings &settings = HSD_CTX.app_settings;
   const std::string  design = settings.interface.properties_panel_design;

--- a/Hesiod/src/gui/widgets/node_settings_widget.cpp
+++ b/Hesiod/src/gui/widgets/node_settings_widget.cpp
@@ -4,6 +4,9 @@
 #include <QLabel>
 #include <QVBoxLayout>
 
+#include "meta_qt/designs/industrial/panel_chrome.hpp"
+#include "meta_qt/ui/theme.hpp"
+
 #include "hesiod/app/hesiod_application.hpp"
 #include "hesiod/gui/widgets/gui_utils.hpp"
 #include "hesiod/gui/widgets/icon_check_box.hpp"
@@ -15,6 +18,20 @@
 
 namespace hesiod
 {
+
+namespace
+{
+
+/// Scrollbar chrome for the panel, taken from the active theme.
+QString panel_scrollbar_style()
+{
+  const auto &theme = meta::qt::ThemeRegistry::instance().get(
+      HSD_CTX.app_settings.interface.properties_panel_theme);
+
+  return meta::qt::industrial::scrollbar_stylesheet(theme);
+}
+
+} // namespace
 
 NodeSettingsWidget::NodeSettingsWidget(QPointer<GraphNodeWidget> p_graph_node_widget,
                                        QWidget                  *parent)
@@ -68,7 +85,6 @@ void NodeSettingsWidget::setup_layout()
   layout->setSpacing(4);
   this->setLayout(layout);
 
-  const int margin = 6;
 
   // --- attributes widget
 
@@ -76,15 +92,26 @@ void NodeSettingsWidget::setup_layout()
     auto *container = new QWidget();
     this->attr_layout = new QVBoxLayout(container);
     this->attr_layout->setAlignment(Qt::AlignTop);
-    this->attr_layout->setContentsMargins(margin, 0, margin, 0);
+
+    // No horizontal margin: section headers are meant to span the full width of
+    // the panel. Sections apply their own padding to their contents instead.
+    this->attr_layout->setContentsMargins(0, 0, 0, 0);
     this->attr_layout->setSpacing(2);
 
     auto *scroll = new QScrollArea();
-    scroll->setHorizontalScrollBarPolicy(Qt::ScrollBarAsNeeded);
+    scroll->setHorizontalScrollBarPolicy(Qt::ScrollBarAlwaysOff);
+
+    // Reserve the vertical scrollbar permanently. An as-needed bar appearing on
+    // expand narrows the viewport and reflows every row, so padding jumps
+    // sideways for reasons unrelated to what was clicked. Costs a few pixels
+    // and removes a whole class of confusion.
+    scroll->setVerticalScrollBarPolicy(Qt::ScrollBarAlwaysOn);
+
     scroll->setWidget(container);
     scroll->setWidgetResizable(true);
     scroll->setFrameShape(QFrame::NoFrame);
     scroll->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
+    scroll->setStyleSheet(panel_scrollbar_style());
 
     layout->addWidget(scroll);
   }

--- a/Hesiod/src/gui/widgets/node_settings_widget.cpp
+++ b/Hesiod/src/gui/widgets/node_settings_widget.cpp
@@ -13,25 +13,12 @@
 #include "hesiod/gui/widgets/node_attributes_widget.hpp"
 #include "hesiod/gui/widgets/node_library_widget.hpp"
 #include "hesiod/gui/widgets/node_settings_widget.hpp"
+#include "hesiod/gui/widgets/properties_panel_design.hpp"
 #include "hesiod/logger.hpp"
 #include "hesiod/model/utils.hpp"
 
 namespace hesiod
 {
-
-namespace
-{
-
-/// Scrollbar chrome for the panel, taken from the active theme.
-QString panel_scrollbar_style()
-{
-  const auto &theme = meta::qt::ThemeRegistry::instance().get(
-      HSD_CTX.app_settings.interface.properties_panel_theme);
-
-  return meta::qt::industrial::scrollbar_stylesheet(theme);
-}
-
-} // namespace
 
 NodeSettingsWidget::NodeSettingsWidget(QPointer<GraphNodeWidget> p_graph_node_widget,
                                        QWidget                  *parent)
@@ -85,33 +72,48 @@ void NodeSettingsWidget::setup_layout()
   layout->setSpacing(4);
   this->setLayout(layout);
 
-
   // --- attributes widget
 
   {
+    // Every bit of panel chrome below is gated on this, so a design that does
+    // not bring its own gets exactly the panel it had before.
+    const PropertiesPanelDesign &panel = properties_panel_design();
+
     auto *container = new QWidget();
     this->attr_layout = new QVBoxLayout(container);
     this->attr_layout->setAlignment(Qt::AlignTop);
 
-    // No horizontal margin: section headers are meant to span the full width of
-    // the panel. Sections apply their own padding to their contents instead.
-    this->attr_layout->setContentsMargins(0, 0, 0, 0);
+    // Section headers are meant to span the full width of the panel, and the
+    // sections apply their own padding to their contents instead. Only the
+    // designs that draw section cards, though: without one, dropping the
+    // margin just leaves every row flush against the edge.
+    if (panel.has_own_chrome)
+      this->attr_layout->setContentsMargins(0, 0, 0, 0);
+
     this->attr_layout->setSpacing(2);
 
     auto *scroll = new QScrollArea();
-    scroll->setHorizontalScrollBarPolicy(Qt::ScrollBarAlwaysOff);
 
-    // Reserve the vertical scrollbar permanently. An as-needed bar appearing on
-    // expand narrows the viewport and reflows every row, so padding jumps
-    // sideways for reasons unrelated to what was clicked. Costs a few pixels
-    // and removes a whole class of confusion.
-    scroll->setVerticalScrollBarPolicy(Qt::ScrollBarAlwaysOn);
+    // As-needed, not off. Some canvases are sized from the array resolution
+    // rather than the dock, so on a narrow dock turning this off left the
+    // right-hand side of a Brush clipped with no way to reach it.
+    scroll->setHorizontalScrollBarPolicy(Qt::ScrollBarAsNeeded);
+
+    if (panel.has_own_chrome)
+    {
+      // Reserve the vertical scrollbar permanently. An as-needed bar appearing
+      // on expand narrows the viewport and reflows every row, so padding jumps
+      // sideways for reasons unrelated to what was clicked. Costs a few pixels
+      // and removes a whole class of confusion.
+      scroll->setVerticalScrollBarPolicy(Qt::ScrollBarAlwaysOn);
+      scroll->setStyleSheet(
+          meta::qt::industrial::scrollbar_stylesheet(*panel.theme));
+    }
 
     scroll->setWidget(container);
     scroll->setWidgetResizable(true);
     scroll->setFrameShape(QFrame::NoFrame);
     scroll->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
-    scroll->setStyleSheet(panel_scrollbar_style());
 
     layout->addWidget(scroll);
   }

--- a/Hesiod/src/gui/widgets/properties_panel_design.cpp
+++ b/Hesiod/src/gui/widgets/properties_panel_design.cpp
@@ -1,0 +1,60 @@
+/* Copyright (c) 2025 Otto Link. Distributed under the terms of the GNU General
+ * Public License. The full license is in the file LICENSE, distributed with
+ * this software. */
+#include "meta_qt/designs/industrial/industrial.hpp"
+#include "meta_qt/designs/stock/stock.hpp"
+#include "meta_qt/ui/design_registry.hpp"
+#include "meta_qt/ui/theme.hpp"
+
+#include "hesiod/app/hesiod_application.hpp"
+#include "hesiod/gui/widgets/properties_panel_design.hpp"
+#include "hesiod/logger.hpp"
+
+namespace hesiod
+{
+
+const PropertiesPanelDesign &properties_panel_design()
+{
+  static const PropertiesPanelDesign resolved = []()
+  {
+    // Designs register once per process. Both of them, so that stock is a
+    // usable fallback rather than another name that resolves to nothing.
+    meta::qt::industrial::register_design();
+    meta::qt::stock::register_design();
+
+    const AppSettings::Interface &settings = HSD_CTX.app_settings.interface;
+
+    PropertiesPanelDesign out;
+    out.design = settings.properties_panel_design;
+
+    if (!meta::qt::DesignRegistry::instance().has_design(out.design))
+    {
+      Logger::log()->warn(
+          "properties_panel_design: '{}' is not a registered design, falling "
+          "back to '{}'. Check interface.properties_panel_design in "
+          "hesiod.json.",
+          out.design,
+          meta::qt::stock::kDesignName);
+
+      out.design = meta::qt::stock::kDesignName;
+    }
+
+    // Designs name their own theme when they register. Point the chosen one at
+    // whatever the settings ask for so the registry stays the single answer to
+    // "what is this design drawn with", rather than the panel reading a theme
+    // the design itself knows nothing about.
+    if (!settings.properties_panel_theme.empty())
+      meta::qt::DesignRegistry::instance().set_theme(
+          out.design,
+          settings.properties_panel_theme);
+
+    out.theme = &meta::qt::DesignRegistry::instance().theme(out.design);
+    out.has_own_chrome = out.design == meta::qt::industrial::kDesignName;
+
+    return out;
+  }();
+
+  return resolved;
+}
+
+} // namespace hesiod

--- a/Hesiod/src/model/nodes/base_node.cpp
+++ b/Hesiod/src/model/nodes/base_node.cpp
@@ -469,8 +469,41 @@ void BaseNode::finalize_attributes()
   // initial state for toolbar Reset and sync common attributes accros
   // group containers
   this->initial_meta_state = group.json_to(meta::SerializationMode::state);
+
+  // The same snapshot kept as live values. The panel needs defaults to decide
+  // what is modified, and reading them back out of the json only ever worked
+  // for the types json round-trips cleanly, which silently left every other
+  // row looking untouched.
+  this->initial_meta_defaults.clear();
+
+  for (const auto &[container_name, p_container] : group.containers())
+  {
+    if (!p_container)
+      continue;
+
+    auto &defaults = this->initial_meta_defaults[container_name];
+
+    for (const auto &key : p_container->insertion_order())
+      if (const auto *p_attr = p_container->find(key))
+        defaults[key] = p_attr->to_any();
+  }
+
   group.synchronize_all();
   group.set_current_to_first();
+}
+
+std::any BaseNode::get_initial_default(const std::string &container_name,
+                                       const std::string &key) const
+{
+  auto container_it = this->initial_meta_defaults.find(container_name);
+  if (container_it == this->initial_meta_defaults.end())
+    return {};
+
+  auto key_it = container_it->second.find(key);
+  if (key_it == container_it->second.end())
+    return {};
+
+  return key_it->second;
 }
 
 void BaseNode::json_from(nlohmann::json const &json)


### PR DESCRIPTION
Hesiod side of the `meta_qt` design layer. Needs ottolink-dev/Meta#47 first, the submodule bump points at it.

Small, about 60 lines, no widgets in here. Replaces #677 which pointed at my fork.

Picks a design and a colourway by name:

```
interface.properties_panel_design = "industrial"
interface.properties_panel_theme  = "palette"
```

Strings rather than enums so registering a design later doesnt mean touching `AppSettings`. Both go through `json_safe_get` so existing configs just keep the compiled default.

`"stock"` is a peer design, so setting it gives you the unmodified panel back. Thats probably the easiest way to review this, flip between the two and theres no rebuild. `"palette"` derives everything from a QPalette, `"industrial-dark"` pins the sampled colourway instead.

**One thing that needed sorting.** Meta derives its base theme from a QPalette so the panel follows the host colour scheme. Hesiod doesnt set an application palette though, it keeps colours in `AppSettings::Colors` and applies them through per-widget stylesheets. Left alone meta_qt would have derived from the *system* palette, so the panel would follow Windows rather than Hesiod and could come up light against the dark app. So the colours get mapped onto a QPalette and handed over. Meta does the derivation, Hesiod supplies the colours, meta_qt still knows nothing about Hesiod.

**Defaults.** The design layer needs each attributes default to colour the modified vs default text. Modified means `|value - default| > 1e-4`, not "changed since the panel opened", and Meta attributes dont carry their own default. `BaseNode::finalize_attributes()` already snapshots one so it reads from that. Anything it cant resolve reports as not modified, since a panel showing every row as modified is worse than one showing none.

**Panel chrome.** The vertical scrollbar is reserved permanently now. An as-needed bar appearing on expand narrows the viewport and reflows every row, so padding jumps sideways for reasons that have nothing to do with what you clicked.

A root section only gets added when a node has no categories of its own. A node with one parameter otherwise renders a single row loose under the toolbar which looks unfinished, but adding a root to a node that already has categories wraps every real section in a second card.

Tested on Qt 6.10.3 / MSVC 2022 with `data/bootstraps/island.hsd`, green on ubuntu CI. Rebased onto current `dev` and bumped HighMap since dev needed the newer one to build.