### PR TITLE
fix(gui): apply the legacy 'out'->'output' port rename to graphics links too

### DIFF
--- a/Hesiod/src/gui/widgets/graph_node_widget.cpp
+++ b/Hesiod/src/gui/widgets/graph_node_widget.cpp
@@ -309,12 +309,32 @@ void GraphNodeWidget::json_from(nlohmann::json const &json)
   Logger::log()->trace("GraphNodeWidget::json_from");
   this->clear_graphic_scene();
 
+  // legacy projects may reference output ports by their pre-consolidation
+  // label "out"; the model applies the same rename in GraphNode::json_from,
+  // and the graphics links need it too or their port lookup fails
+  nlohmann::json gui_json = json;
+
+  if (auto gno = this->p_graph_node.lock())
+    if (gui_json.contains("links") && gui_json["links"].is_array())
+      for (auto &json_link : gui_json["links"])
+      {
+        const std::string node_out_id = json_link.value("node_out_id", "");
+        const std::string port_out_id = json_link.value("port_out_id", "");
+
+        if (auto *p_from = gno->get_node(node_out_id))
+          if (port_out_id == "out" && p_from->get_port_index("out") == -1 &&
+              p_from->get_port_index("output") != -1)
+          {
+            json_link["port_out_id"] = "output";
+          }
+      }
+
   // the graph model loading and updating is taken care of by
   // GraphNode (model) and does not need to be updated again when the
   // graphics object are recreated (and are going to trigger signals
   // requesting some model updates...)
   this->set_block_graph_model_updates(true);
-  GraphViewer::json_from(json);
+  GraphViewer::json_from(gui_json);
   this->set_block_graph_model_updates(false);
 
   // viewers (skipped in headless CLI modes, e.g. --snapshot: no 3D viewer is


### PR DESCRIPTION
## Problem

Opening any pre-consolidation project that wires one of the former noise nodes' outputs crashes on load:

```
Qt has caught an exception thrown from an event handler.
[hesiod] [---C---] Fatal: unhandled exception, Hesiod is shutting down: Invalid output port index
```

The noise consolidation (de9fbe18) renamed the output port `out` -> `output` and added a rename shim to the model loader (`GraphNode::json_from`). But the `.hsd` stores a second, GUI-owned links array, and `GraphNodeWidget::json_from` hands its labels to `GraphViewer::add_link` unshimmed: `get_port_index("out")` returns `-1`, and `get_data_type(-1)` throws `std::out_of_range` from inside a Qt slot.

Repro: open `docs/meta-migration/stress/g10-with-heart.hsd` (contains legacy Noise/NoiseIq/NoiseParberry/NoisePingpong/NoiseRidged nodes).

## Fix

Mirror the model-side rename on the GUI links array before passing it to `GraphViewer::json_from`, under the same condition (only when the node no longer has `out` but has `output` — nodes that legitimately still use `out` are untouched).

Verified: g10-with-heart.hsd loads fully wired (GUI-checked), headless load shows no skipped links.

## Notes

- 21 nodes still use `out` as their P_OUT label today (vs 198 on `output`). If those are standardized later, this shim pair already covers loading their old projects — issue to follow tracking the renames.
- A sibling GNodeGUI PR makes `GraphViewer::add_link` skip-and-log unknown port ids instead of crashing the host app, as defense in depth.
- Longer term the double bookkeeping could go away entirely if the GUI derived link wiring from the model instead of serializing its own copy — left as a suggestion.