### PR TITLE
feat: issue forms with a Theme dropdown, and an auto-labelling workflow

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,48 @@
+name: Bug report
+description: Something broken or behaving unexpectedly
+labels: []
+body:
+  - type: textarea
+    id: description
+    attributes:
+      label: Describe the bug
+      description: What happens, and what you expected instead
+    validations:
+      required: true
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to reproduce
+      placeholder: |
+        1. Open ...
+        2. Add a ... node
+        3. See ...
+    validations:
+      required: true
+  - type: dropdown
+    id: theme
+    attributes:
+      label: Theme
+      description: Which part of Hesiod is this about? "Not sure" is a fine answer.
+      options:
+        - Not sure
+        - Erosion & hydrology
+        - Nodes & algorithms
+        - Graph editor UX
+        - Attributes & widgets
+        - Rendering & viewport
+        - Terrain semantics
+        - Serialization & compat
+        - Performance & memory
+        - Textures
+        - Export & integrations
+        - Docs & examples
+        - Build & platform
+        - Application & CLI
+    validations:
+      required: true
+  - type: input
+    id: version
+    attributes:
+      label: Hesiod version / platform
+      placeholder: e.g. v0.6.0 dev build, Windows 11 / NixOS

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: true

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,33 @@
+name: Feature request
+description: An idea for a node, a workflow, or an improvement
+labels: []
+body:
+  - type: textarea
+    id: description
+    attributes:
+      label: What would you like?
+      description: The feature, and the terrain/workflow problem it solves
+    validations:
+      required: true
+  - type: dropdown
+    id: theme
+    attributes:
+      label: Theme
+      description: Which part of Hesiod is this about? "Not sure" is a fine answer.
+      options:
+        - Not sure
+        - Erosion & hydrology
+        - Nodes & algorithms
+        - Graph editor UX
+        - Attributes & widgets
+        - Rendering & viewport
+        - Terrain semantics
+        - Serialization & compat
+        - Performance & memory
+        - Textures
+        - Export & integrations
+        - Docs & examples
+        - Build & platform
+        - Application & CLI
+    validations:
+      required: true

--- a/.github/workflows/theme-label.yml
+++ b/.github/workflows/theme-label.yml
@@ -1,0 +1,93 @@
+name: Theme label
+
+on:
+  issues:
+    types: [opened]
+  discussion:
+    types: [created]
+
+permissions:
+  issues: write
+  discussions: write
+  contents: read
+
+jobs:
+  theme:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/github-script@v7
+        with:
+          script: |
+            const DROPDOWN = {
+              "Erosion & hydrology": "theme: erosion-hydrology",
+              "Nodes & algorithms": "theme: nodes-algorithms",
+              "Graph editor UX": "theme: graph-editor-ux",
+              "Attributes & widgets": "theme: attributes-widgets",
+              "Rendering & viewport": "theme: rendering-viewport",
+              "Terrain semantics": "theme: terrain-semantics",
+              "Serialization & compat": "theme: serialization-compat",
+              "Performance & memory": "theme: performance-memory",
+              "Textures": "theme: textures",
+              "Export & integrations": "theme: export-integrations",
+              "Docs & examples": "theme: docs-examples",
+              "Build & platform": "theme: build-platform",
+              "Application & CLI": "theme: application"
+            };
+            const KEYWORDS = {
+              "theme: erosion-hydrology": ["erosion", "hydraulic", "river", "rivers", "water", "flood", "flooding", "flow", "sediment", "snow", "coastal", "talus", "thermal", "watershed", "rain", "lake", "drainage"],
+              "theme: nodes-algorithms": ["node", "nodes", "primitive", "noise", "blend", "mask", "kernel", "voronoi", "path", "cloud", "carve", "carving", "stamp", "crater", "rift", "warp", "algorithm", "heightmap"],
+              "theme: graph-editor-ux": ["graph", "link", "links", "menu", "keyboard", "selection", "shortcut", "layout", "clipboard", "port", "ports", "undo", "redo", "zoom", "drag"],
+              "theme: attributes-widgets": ["attribute", "attributes", "widget", "slider", "palette", "brush", "canvas", "curve", "gradient", "tooltip"],
+              "theme: rendering-viewport": ["render", "rendering", "viewport", "shader", "camera", "tessellation", "lighting", "mesh", "skybox", "opengl", "imgui", "fog"],
+              "theme: terrain-semantics": ["settlement", "settlements", "vegetation", "semantic", "semantics", "landscape", "placement"],
+              "theme: serialization-compat": ["serialize", "serialization", "save", "load", "hsd", "legacy", "autosave", "json", "compat", "compatibility", "project"],
+              "theme: performance-memory": ["performance", "perf", "optimize", "optimization", "memory", "footprint", "slow", "allocation", "freeze"],
+              "theme: textures": ["texture", "textures", "download", "ambientcg"],
+              "theme: export-integrations": ["export", "blender", "bridge", "cubemap", "ply", "integration", "obj", "gltf"],
+              "theme: docs-examples": ["documentation", "docs", "example", "examples", "tutorial", "reference", "guide"],
+              "theme: build-platform": ["build", "msvc", "windows", "cmake", "packaging", "compile", "compilation", "portability", "appimage", "linux", "macos"],
+              "theme: application": ["cli", "settings", "window", "startup", "application", "headless", "launcher"]
+            };
+
+            const isDiscussion = !!context.payload.discussion;
+            const target = context.payload.discussion || context.payload.issue;
+            const existing = (target.labels || []).map(l => (typeof l === "string" ? l : l.name));
+            if (existing.some(l => l.startsWith("theme:"))) return;
+
+            let label = null;
+            const m = (target.body || "").match(/###\s*Theme\s*\n+\s*(.+)/i);
+            if (m) label = DROPDOWN[m[1].trim()] || null;
+
+            if (!label) {
+              const words = s => (s || "").toLowerCase().match(/[a-z]{2,}/g) || [];
+              const title = new Set(words(target.title));
+              const body = new Set(words(target.body).slice(0, 250));
+              let best = 0;
+              for (const [lbl, kws] of Object.entries(KEYWORDS)) {
+                let score = 0;
+                for (const k of kws) score += (title.has(k) ? 3 : 0) + (body.has(k) ? 1 : 0);
+                if (score > best) { best = score; label = lbl; }
+              }
+              if (best < 3) label = null; // require a title hit or several body hits
+            }
+
+            const apply = label || "needs-theme";
+            if (isDiscussion) {
+              const q = await github.graphql(
+                `query($owner:String!,$repo:String!,$name:String!){repository(owner:$owner,name:$repo){label(name:$name){id}}}`,
+                { owner: context.repo.owner, repo: context.repo.repo, name: apply }
+              );
+              const labelId = q.repository.label && q.repository.label.id;
+              if (!labelId) return core.warning(`label not found: ${apply}`);
+              await github.graphql(
+                `mutation($l:ID!,$ids:[ID!]!){addLabelsToLabelable(input:{labelableId:$l,labelIds:$ids}){clientMutationId}}`,
+                { l: target.node_id, ids: [labelId] }
+              );
+            } else {
+              await github.rest.issues.addLabels({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: target.number,
+                labels: [apply]
+              });
+            }


### PR DESCRIPTION
Follow-up to the theme layer (discussion #717) — Otto asked for the theme dropdown "from the start".

## What's in it

- **Bug report / feature request issue forms** with a required **Theme** dropdown matching the 13 `theme:` labels ("Not sure" is a legitimate answer — forcing a confused filer produces bad data). Blank issues stay enabled.
- **`theme-label` workflow** on `issues: opened` / `discussion: created`: maps the dropdown to the matching `theme:` label; when the dropdown is absent or "Not sure", a keyword classifier takes over (title hits weighted 3×, and below a confidence threshold it declines to guess); anything it can't place gets `needs-theme` so gaps stay queryable rather than invisible. Items that already carry a `theme:` label are left untouched.
- Security posture: issue/discussion title and body are only ever handled as data inside `github-script` — no `${{ }}` interpolation of untrusted text, no `run:` steps.

Adapted from the same mechanism running on the Fantasy-Map-Generator repo (Azgaar/Fantasy-Map-Generator#1772).

## Note on activation

Issue templates and issue-event workflows only take effect from the **default branch**, so this becomes live when this lands on `main` (e.g. with the next dev→main release merge, or a cherry-pick of this single commit if wanted sooner). The `needs-theme` label already exists in all six repos.