### PR TITLE
fix(nodes): make the path and brush attributes declare what they are

### DIFF
--- a/Hesiod/src/model/nodes/attributes.cpp
+++ b/Hesiod/src/model/nodes/attributes.cpp
@@ -265,7 +265,9 @@ meta::Attribute<std::vector<glm::vec3>> &add_path(BaseNode          &node,
                                                   bool               closed)
 {
   auto &a = meta::presets::points(node.get_meta_group().current(), key, label);
-  a.metadata().try_add(meta::keys::ui::widget_type, std::string("PathEditor"));
+  a.metadata()
+      .try_add(meta::keys::ui::widget_type, std::string("PathEditor"))
+      ->value() = "PathEditor";
   a.metadata().try_add(std::string(meta::keys::ui::closed), closed);
   set_doc_type(a, "Path");
   apply_category_if_set(node, a);

--- a/Hesiod/src/model/nodes/nodes_function/brush.cpp
+++ b/Hesiod/src/model/nodes/nodes_function/brush.cpp
@@ -1,6 +1,8 @@
 /* Copyright (c) 2023 Otto Link. Distributed under the terms of the GNU General
  * Public License. The full license is in the file LICENSE, distributed with
  * this software. */
+#include "meta/metadata/keys.hpp"
+
 #include "hesiod/logger.hpp"
 #include "hesiod/model/nodes/attributes.hpp"
 #include "hesiod/model/nodes/base_node.hpp"
@@ -24,7 +26,12 @@ void setup_brush_node(BaseNode &node)
   node.add_port<hmap::VirtualArray>(gnode::PortType::OUT, P_OUT, CONFIG(node));
 
   // attribute(s)
-  add_array(node, "hmap", "HeightMap");
+  // Categorised so the industrial panel gives the canvas its own section
+  // rather than dropping it into the node's root group.
+  auto &paint = add_array(node, "hmap", "HeightMap");
+  paint.metadata()
+      .try_add(std::string(meta::keys::ui::category), std::string("Brush"))
+      ->value() = "Brush";
 
   setup_post_process_heightmap_attributes(node,
                                           {.add_mix = true, .remap_active_state = true});


### PR DESCRIPTION
two small metadata fixes the properties panel needs. neither touches the meta
side, theyre both just wrong on their own terms.

add_path asks for the PathEditor widget type with try_add, but try_add hands
back the existing entry when theres already one and quietly drops the new
value. presets::points has already set PointsEditor by that point, so every
path attribute in the app has been declaring itself a points editor and no
path has ever actually got the editor thats written for it. assigning through
the returned entry makes the intent land.

the brush nodes heightmap had no category at all so it fell into the nodes root
group and the canvas ended up sharing a section with unrelated parameters.
giving it one puts it in its own section, which is what a canvas row wants.

related to ottolink-dev/Meta#56, which is where the path and brush canvases
themselves get reworked, but this doesnt depend on it and can go in whenever.
