### PR TITLE
Match graph canvas to industrial properties theme

### DIFF
--- a/Hesiod/src/gui/widgets/graph_tabs_widget.cpp
+++ b/Hesiod/src/gui/widgets/graph_tabs_widget.cpp
@@ -4,12 +4,14 @@
 #include <QHBoxLayout>
 
 #include "gnodegui/style.hpp"
+#include "meta_qt/ui/theme.hpp"
 
 #include "hesiod/app/hesiod_application.hpp"
 #include "hesiod/gui/widgets/graph_editor_widget.hpp"
 #include "hesiod/gui/widgets/graph_node_widget.hpp"
 #include "hesiod/gui/widgets/graph_tabs_widget.hpp"
 #include "hesiod/gui/widgets/node_settings_widget.hpp"
+#include "hesiod/gui/widgets/properties_panel_design.hpp"
 #include "hesiod/gui/widgets/viewers/viewer_3d.hpp"
 #include "hesiod/logger.hpp"
 #include "hesiod/model/graph/graph_manager.hpp"
@@ -34,6 +36,45 @@ GraphTabsWidget::GraphTabsWidget(std::weak_ptr<GraphManager> p_graph_manager,
   GN_STYLE->node.color_port_data = ctx.style_settings.data_color_map;
   GN_STYLE->node.color_category = ctx.style_settings.category_color_map;
   GN_STYLE->node.port_radius = ctx.app_settings.node_editor.port_radius;
+
+  const auto &design = properties_panel_design();
+  if (design.has_own_chrome)
+  {
+    const auto &theme = *design.theme;
+    auto       &node = GN_STYLE->node;
+    auto       &viewer = GN_STYLE->viewer;
+    auto       &link = GN_STYLE->link;
+
+    // Use the panel's actual card surfaces and inks, including palette-derived
+    // themes. Category fills would otherwise override color_bg_light.
+    node.color_category.clear();
+    node.color_bg = theme.section_surface;
+    node.color_bg_light = theme.section_header;
+    node.color_border = theme.hairline;
+    node.color_border_hovered = theme.field_border_hover;
+    node.color_caption = theme.ink_section_title;
+    node.color_icon = theme.ink_icon;
+    node.color_comment = theme.ink_secondary;
+    node.color_selected = theme.accent;
+    node.color_pinned = theme.accent;
+    node.color_port_hovered = theme.accent;
+    node.color_port_selected = theme.accent;
+    node.color_port_data_default = theme.ink_secondary;
+    node.color_port_not_selectable = theme.ink_locked;
+
+    // Header and body share the card outline; the panel's smaller control
+    // radius belongs to embedded controls, not to either half of this card.
+    node.rounding_radius = theme.metrics.section_card_radius;
+    node.pen_width = 1.f;
+    node.pen_width_hovered = 1.f;
+
+    viewer.color_bg = theme.page;
+    viewer.color_toolbar = theme.ink_icon;
+    // Typed links retain their semantic data colours, like the panel's group
+    // accents. Untyped links use secondary ink; selection uses chrome accent.
+    link.color_default = theme.ink_secondary;
+    link.color_selected = theme.accent;
+  }
 
   this->main_layout = new QHBoxLayout(this);
   this->main_layout->setContentsMargins(2, 2, 2, 2);

--- a/Hesiod/src/gui/widgets/graph_tabs_widget.cpp
+++ b/Hesiod/src/gui/widgets/graph_tabs_widget.cpp
@@ -1,6 +1,9 @@
 /* Copyright (c) 2025 Otto Link. Distributed under the terms of the GNU General
  * Public License. The full license is in the file LICENSE, distributed with
  * this software. */
+#include <map>
+
+#include <QColor>
 #include <QHBoxLayout>
 
 #include "gnodegui/style.hpp"
@@ -37,6 +40,11 @@ GraphTabsWidget::GraphTabsWidget(std::weak_ptr<GraphManager> p_graph_manager,
   GN_STYLE->node.color_category = ctx.style_settings.category_color_map;
   GN_STYLE->node.port_radius = ctx.app_settings.node_editor.port_radius;
 
+  // How far a node header is pulled from the card surface towards its category
+  // colour. High enough to tell two categories apart side by side, low enough
+  // that a canvas full of nodes still reads as one neutral surface.
+  constexpr qreal kCategoryTint = 0.22;
+
   const auto &design = properties_panel_design();
   if (design.has_own_chrome)
   {
@@ -45,9 +53,32 @@ GraphTabsWidget::GraphTabsWidget(std::weak_ptr<GraphManager> p_graph_manager,
     auto       &viewer = GN_STYLE->viewer;
     auto       &link = GN_STYLE->link;
 
-    // Use the panel's actual card surfaces and inks, including palette-derived
-    // themes. Category fills would otherwise override color_bg_light.
-    node.color_category.clear();
+    // Keep the per-category signal, but express it the way the panel does. A
+    // group accent there is a small saturated mark against neutral chrome, not
+    // a whole surface, and these are saturated Solarized hues that fill an
+    // entire node header. Blending each one heavily towards the card leaves
+    // every category still distinguishable while the canvas stays the neutral
+    // grey the design is built on.
+    //
+    // Clearing the map instead was the first attempt, and it cost the thing
+    // the colours are for: telling an erosion node from a noise node at a
+    // glance. Theme keeps group_accents out of from_palette() for exactly this
+    // reason, because they encode which family an operation belongs to rather
+    // than tracking a host accent.
+    auto tint_towards = [](const QColor &surface, const QColor &accent, qreal t)
+    {
+      return QColor::fromRgbF(surface.redF() * (1.0 - t) + accent.redF() * t,
+                              surface.greenF() * (1.0 - t) + accent.greenF() * t,
+                              surface.blueF() * (1.0 - t) + accent.blueF() * t);
+    };
+
+    std::map<std::string, QColor> tinted_categories;
+    for (const auto &[category, color] : ctx.style_settings.category_color_map)
+      tinted_categories[category] = tint_towards(theme.section_header,
+                                                 color,
+                                                 kCategoryTint);
+
+    node.color_category = tinted_categories;
     node.color_bg = theme.section_surface;
     node.color_bg_light = theme.section_header;
     node.color_border = theme.hairline;


### PR DESCRIPTION
When the industrial properties design is active, the graph canvas now uses the same resolved meta::qt::Theme for node card surfaces, caption/icon/comment inks, borders, canvas background, and selection accent. Clear the category header-fill override in this mode so it cannot replace the shared neutral card surface. Typed ports and links retain their semantic data colours; fallback links use secondary ink and selected links use the theme accent.

Use the panel's section_card_radius for the shared node header/body outline and 1px ordinary/hover borders. All new assignments are guarded by properties_panel_design().has_own_chrome, leaving the stock style path intact. No GNodeGUI source or submodule revision changes are included.

Optional bevels and the currently hardcoded port-label ink are a separate upstream proposal: https://github.com/ottolink-dev/GNodeGUI/pull/11. The 4px control radius and machined thumb gradients belong to embedded control renderers, not node cards.

Validation: build_hesiod.bat passed with existing dependency warnings; run_hesiod.bat launched the built executable and the process was confirmed running. git diff --check passed. Visual review is delegated to the user because screen capture is unavailable: compare canvas/card neutrals with the panel, inspect selection and hover, typed connections, pinned nodes and icons; restart with the stock design to check the original appearance. No visual approval is claimed.
