### PR TITLE
Add interface scaling and an optional node palette sidebar

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,6 +20,9 @@ add_compile_definitions(
 # ------------------------------
 option(HESIOD_ENABLE_GENERATE_APP_IMAGE "Enable AppImage generation" ON)
 
+option(HESIOD_ENABLE_UI_TESTS
+       "Build the interface scale / node palette regression tests" ON)
+
 option(HESIOD_MINIMAL_NODE_SET
        "Use a minimal set of nodes (ADVANCED DEV ONLY!!!)" OFF)
 
@@ -74,6 +77,10 @@ message(STATUS "└────────────────────�
 # ------------------------------
 add_subdirectory(external)
 add_subdirectory(Hesiod)
+
+if(HESIOD_ENABLE_UI_TESTS)
+  add_subdirectory(tests)
+endif()
 
 if(HESIOD_ENABLE_GENERATE_APP_IMAGE)
   add_subdirectory(scripts/generate_appimage)

--- a/Hesiod/app/main.cpp
+++ b/Hesiod/app/main.cpp
@@ -6,7 +6,10 @@ typedef unsigned int uint;
 #include <exception>
 #include <new>
 
+#include <QCoreApplication>
+
 #include "hesiod/app/hesiod_application.hpp"
+#include "hesiod/app/ui_scale.hpp"
 #include "hesiod/cli/batch_mode.hpp"
 #include "hesiod/logger.hpp"
 
@@ -35,6 +38,14 @@ int main(int argc, char *argv[])
           "--ignore-gpu-blocklist "
           "--enable-webgl "
           "--disable-gpu-driver-bug-workarounds");
+
+  // The interface scale has to reach Qt before QApplication is constructed:
+  // high-DPI scaling is resolved once, at that point. Pinning the application
+  // name first makes QStandardPaths give the same config directory the running
+  // application will use, which it otherwise only derives from argv[0] once an
+  // instance exists.
+  QCoreApplication::setApplicationName("hesiod");
+  hesiod::ui_scale::apply_startup_scale(argc > 0 ? argv[0] : nullptr);
 
   // Backstop only: anything that reaches here has already escaped the guards
   // around graph updates. Reporting it and exiting non-zero beats std::terminate

--- a/Hesiod/include/hesiod/app/app_settings.hpp
+++ b/Hesiod/include/hesiod/app/app_settings.hpp
@@ -6,6 +6,8 @@
 
 #include "nlohmann/json.hpp"
 
+#include "hesiod/gui/node_palette_style.hpp"
+
 #define HSD_ICON(name)                                                                   \
   static_cast<hesiod::HesiodApplication *>(QCoreApplication::instance())                 \
       ->get_context()                                                                    \
@@ -107,7 +109,25 @@ struct AppSettings
     // "industrial-dark" pins the reference colourway instead.
     std::string properties_panel_design = "industrial";
     std::string properties_panel_theme = "palette";
+
+    // Application-wide interface scale. Handed to Qt as QT_SCALE_FACTOR before
+    // QApplication exists, so it multiplies into the per-monitor DPI factor
+    // instead of fighting it, and every logical metric follows. Applied at
+    // startup only -- see ui_scale.hpp for why, and for the validation rules.
+    double ui_scale = 1.0;
+
+    // Gaea-style category rail with hierarchical flyouts instead of the dense
+    // library tree. Off by default: the tree is the shipped sidebar and this is
+    // an alternative, not a replacement.
+    bool enable_node_palette_sidebar = false;
+
+    // Interface motion (rail cross-fades, menu/tooltip effects, tree expand
+    // animation). Turning it off settles running animations immediately.
+    bool enable_ui_animations = true;
   } interface;
+
+  /// Look of the node palette sidebar. Only read when it is enabled.
+  NodePaletteStyle node_palette;
 
   struct NodeEditor
   {

--- a/Hesiod/include/hesiod/app/ui_scale.hpp
+++ b/Hesiod/include/hesiod/app/ui_scale.hpp
@@ -1,0 +1,101 @@
+/* Copyright (c) 2026 Otto Link. Distributed under the terms of the GNU General Public
+   License. The full license is in the file LICENSE, distributed with this software. */
+#pragma once
+#include <string>
+
+/** @file ui_scale.hpp
+ *  @brief Application-wide interface scaling.
+ *
+ *  Scaling is applied once, before QApplication exists, by handing the factor
+ *  to Qt itself (QT_SCALE_FACTOR). Qt then multiplies it into the per-monitor
+ *  device pixel ratio, so a 150% monitor at scale 1.25 renders at 1.875 rather
+ *  than either factor being lost or applied twice, and every logical metric --
+ *  point-sized fonts, stylesheet px, fixed widths, icons, layout spacing --
+ *  follows without any widget knowing about it.
+ *
+ *  Deliberately *not* implemented by walking widgets and multiplying their
+ *  metrics: that mutates the metrics in place, so a second change compounds on
+ *  the first, and it silently misses every fixed size set in a constructor.
+ *  Here the baseline is the source code's own logical values, which are never
+ *  touched, and the factor is an absolute number read fresh at startup. Two
+ *  changes in a row therefore give the same result as jumping straight to the
+ *  second one.
+ *
+ *  The cost is that a change lands on restart. Qt cannot re-run high-DPI
+ *  scaling on a live application, and the alternatives that do work live (font
+ *  substitution plus a stylesheet rewrite) leave the hard-coded widget sizes
+ *  behind and look broken at anything past ~1.3.
+ */
+
+namespace hesiod::ui_scale
+{
+
+inline constexpr double kMin = 0.5;
+inline constexpr double kMax = 3.0;
+inline constexpr double kDefault = 1.0;
+inline constexpr double kStep = 0.05;
+
+/** @brief Make a persisted or user-entered factor safe to use.
+ *
+ * Non-finite values (NaN, +/-inf) and anything that is not a number fall back
+ * to @ref kDefault; a finite value outside the supported window is clamped into
+ * it. `out_was_clean` reports whether the input was already usable as-is, which
+ * is what lets the loader log a corrected config instead of silently changing
+ * the user's setting.
+ */
+double sanitize(double value, bool *out_was_clean = nullptr);
+
+/** @brief Directory holding the running executable, before QApplication exists.
+ *
+ * On Windows this asks the loader (GetModuleFileNameW) rather than trusting
+ * argv[0]: a process started through PATH, a shortcut or CreateProcess can be
+ * handed a bare name or a relative path, which would resolve the portable
+ * config against whatever directory the launcher happened to be in. @p argv0 is
+ * only the fallback.
+ */
+std::string executable_dir(const char *argv0);
+
+/** @brief Config file path, resolved without a QCoreApplication instance.
+ *
+ * Mirrors get_config_file_path_auto("hesiod"): a hesiod.json or portable.flag
+ * next to the executable wins, otherwise the per-user config location. Needed
+ * because the scale has to be known before QApplication is constructed, and
+ * QCoreApplication::applicationDirPath() is not available that early.
+ */
+std::string startup_config_path(const char *argv0);
+
+/// Scale stored in @p config_path, sanitized. Missing file, malformed JSON or a
+/// missing/ill-typed key all yield @ref kDefault.
+double scale_from_config(const std::string &config_path);
+
+/** @brief What the settings asked for versus what the process actually runs at.
+ *
+ * The two differ when QT_SCALE_FACTOR is already set in the environment: Qt
+ * obeys that, the preference is not applied, and reporting the preference as if
+ * it were active is how a user ends up believing the setting is broken.
+ */
+struct Resolution
+{
+  double configured = kDefault; ///< the persisted preference, sanitized
+  double effective = kDefault;  ///< what Qt will actually scale by
+  bool   environment_override = false; ///< QT_SCALE_FACTOR came from outside
+};
+
+/** @brief Hand @p configured to Qt, unless the environment already spoke.
+ *
+ * Must run before QApplication is constructed. Records the outcome for
+ * session_resolution(). Split from the config read so the decision is testable
+ * without touching a settings file.
+ */
+Resolution apply_scale(double configured);
+
+/// scale_from_config(startup_config_path(argv0)) fed to apply_scale().
+Resolution apply_startup_scale(const char *argv0);
+
+/// What apply_scale() decided, or an unapplied default if it never ran.
+Resolution session_resolution();
+
+/// The factor this process actually runs at, 1.0 if apply_scale() never ran.
+double session_scale();
+
+} // namespace hesiod::ui_scale

--- a/Hesiod/include/hesiod/gui/node_palette_style.hpp
+++ b/Hesiod/include/hesiod/gui/node_palette_style.hpp
@@ -1,0 +1,48 @@
+/* Copyright (c) 2026 Otto Link. Distributed under the terms of the GNU General Public
+   License. The full license is in the file LICENSE, distributed with this software. */
+#pragma once
+#include <QColor>
+
+namespace hesiod
+{
+
+/** @brief Colours, spacing and motion for the node palette sidebar.
+ *
+ * A plain value type on purpose: the widget never reads application settings,
+ * it is handed a style. That keeps it testable without an application context
+ * and makes a live restyle a single assignment rather than a rebuild. It also
+ * lets AppSettings hold one of these without depending on any widget.
+ *
+ * Every metric is a *logical* pixel count at 100% interface scale. Nothing here
+ * multiplies them: Qt's high-DPI scaling (see ui_scale.hpp) does that, so
+ * changing the interface scale twice cannot compound into these numbers.
+ */
+struct NodePaletteStyle
+{
+  // --- surfaces
+  QColor surface{"#242424"};          ///< resting category button
+  QColor surface_hover{"#303030"};    ///< hovered category button
+  QColor surface_selected{"#3b3b3b"}; ///< category whose flyout is open
+  QColor flyout_bg{"#1e1e1e"};
+  QColor flyout_border{"#3a3a3a"};
+  QColor text{"#b9b9b9"};
+  QColor text_active{"#f2f2f2"};
+
+  // --- metrics, logical px
+  int button_height = 40;
+  int button_spacing = 6;
+  int rail_padding = 8;
+  int icon_size = 22;
+  int corner_radius = 8;
+  int flyout_row_height = 28;
+  int flyout_padding = 6;
+
+  // --- motion
+  bool animations = true;
+  int  animation_ms = 120;
+
+  /// 0 keeps the category glyph neutral, 1 paints it in the category colour.
+  double accent_strength = 1.0;
+};
+
+} // namespace hesiod

--- a/Hesiod/include/hesiod/gui/widgets/app_settings_window.hpp
+++ b/Hesiod/include/hesiod/gui/widgets/app_settings_window.hpp
@@ -1,6 +1,9 @@
 /* Copyright (c) 2025 Otto Link. Distributed under the terms of the GNU General Public
    License. The full license is in the file LICENSE, distributed with this software. */
 #pragma once
+#include <functional>
+#include <string>
+
 #include <QFormLayout>
 #include <QObject>
 #include <QWidget>
@@ -16,12 +19,25 @@ public:
 
 private:
   void setup_layout();
+  void setup_interface_scale_row();
 
   void add_description(const std::string &description, int max_length = 64);
   void add_title(const std::string &label, int font_size_delta = 2);
-  void bind_bool(const std::string &label, bool &state);
+  void bind_bool(const std::string    &label,
+                 bool                 &state,
+                 std::function<void(bool)> on_changed = nullptr);
   void bind_int(const std::string &label, int &value);
+  /// Spin box over an explicit range, for a metric with real bounds.
+  void bind_int_range(const std::string &label,
+                      int               &value,
+                      int                min,
+                      int                max,
+                      const std::string &suffix = " px");
   void bind_qcolor(const std::string &label, QColor &color);
+
+  /// Repaint the running application after a colour changed, so the setting is
+  /// visible without a restart.
+  void refresh_theme();
 
   QFormLayout *layout;
 };

--- a/Hesiod/include/hesiod/gui/widgets/graph_editor_widget.hpp
+++ b/Hesiod/include/hesiod/gui/widgets/graph_editor_widget.hpp
@@ -4,6 +4,7 @@
 #include <memory>
 
 #include "hesiod/gui/widgets/node_library_widget.hpp"
+#include "hesiod/gui/widgets/node_palette_sidebar.hpp"
 #include "hesiod/model/nodes/base_node.hpp"
 
 class QToolButton;
@@ -46,9 +47,14 @@ private:
   std::weak_ptr<GraphNode> p_graph_node;
   GraphNodeWidget         *graph_node_widget = nullptr;
   NodeSettingsWidget      *node_settings_widget = nullptr;
-  NodeLibraryWidget       *node_library_widget = nullptr;
-  Viewer3D                *viewer = nullptr;
-  QToolButton             *node_library_toggle_button = nullptr;
+
+  // exactly one of these is built, chosen by
+  // interface.enable_node_palette_sidebar; the other stays null
+  NodeLibraryWidget  *node_library_widget = nullptr;
+  NodePaletteSidebar *node_palette_sidebar = nullptr;
+
+  Viewer3D    *viewer = nullptr;
+  QToolButton *node_library_toggle_button = nullptr;
 };
 
 } // namespace hesiod

--- a/Hesiod/include/hesiod/gui/widgets/gui_utils.hpp
+++ b/Hesiod/include/hesiod/gui/widgets/gui_utils.hpp
@@ -10,12 +10,26 @@
 #include <QLayout>
 #include <QWidget>
 
+#include "hesiod/gui/node_palette_style.hpp"
+
 namespace hesiod
 {
 
 void add_qmenu_spacer(QMenu *menu, int height = 8);
 
 void apply_global_style(QApplication &app);
+
+/** @brief Switch interface motion on or off across the application.
+ *
+ * Covers Qt's own menu/combo/tooltip effects and any node palette sidebar that
+ * is already open. Called at startup and again whenever the setting changes,
+ * because "disable animations" that only applies to windows opened afterwards
+ * reads as the setting not working.
+ */
+void apply_animation_settings(bool enabled);
+
+/// The node palette style currently configured in the application settings.
+NodePaletteStyle current_node_palette_style();
 
 void clear_layout(QLayout *layout);
 

--- a/Hesiod/include/hesiod/gui/widgets/node_palette_sidebar.hpp
+++ b/Hesiod/include/hesiod/gui/widgets/node_palette_sidebar.hpp
@@ -1,0 +1,163 @@
+/* Copyright (c) 2026 Otto Link. Distributed under the terms of the GNU General Public
+   License. The full license is in the file LICENSE, distributed with this software. */
+#pragma once
+#include <map>
+#include <string>
+#include <vector>
+
+#include <QAbstractButton>
+#include <QColor>
+#include <QLineEdit>
+#include <QMenu>
+#include <QPointer>
+#include <QVariantAnimation>
+#include <QWidget>
+
+#include "hesiod/gui/node_palette_style.hpp"
+
+namespace hesiod
+{
+
+// =====================================
+// CategoryRailButton
+// =====================================
+
+/** @brief One category in the vertical rail: glyph, label, hover/open state.
+ *
+ * Custom-painted rather than a styled QPushButton because the resting/hover
+ * cross-fade has to be interruptible and has to settle *immediately* when
+ * animations are switched off, which a stylesheet :hover cannot express.
+ */
+class CategoryRailButton : public QAbstractButton
+{
+  Q_OBJECT
+
+public:
+  CategoryRailButton(const QString          &category,
+                     const QColor           &accent,
+                     const NodePaletteStyle &style,
+                     QWidget                *parent = nullptr);
+
+  void set_style(const NodePaletteStyle &style);
+
+  /// True while this category's flyout is open; drives the selected surface.
+  void set_open(bool state);
+  bool is_open() const;
+
+  /// Current surface colour, i.e. where the cross-fade actually is.
+  QColor current_surface() const;
+
+  QSize sizeHint() const override;
+
+signals:
+  /// Pointer entered the button. The rail uses this to switch open flyouts.
+  void hovered();
+
+protected:
+  void enterEvent(QEnterEvent *event) override;
+  void leaveEvent(QEvent *event) override;
+  void paintEvent(QPaintEvent *event) override;
+
+private:
+  QColor target_surface() const;
+  void   retarget_surface();
+
+  QString           category;
+  QColor            accent;
+  NodePaletteStyle  style;
+  bool              open = false;
+  bool              hovering = false;
+  QColor            surface;
+  QVariantAnimation surface_animation;
+};
+
+// =====================================
+// NodePaletteSidebar
+// =====================================
+
+/** @brief Category rail with hierarchical flyouts, as an alternative to the
+ *  dense node library tree.
+ *
+ * Built from the application's own node inventory (node type -> "Cat/Sub/..."),
+ * so it cannot drift out of sync with the registry: every node reachable in the
+ * tree is reachable here. It emits the same three activation signals as
+ * NodeLibraryWidget and is wired to the same node-creation slots, so both
+ * sidebars create nodes through one code path.
+ *
+ * Flyouts are QMenus rather than hand-rolled popups. That is what buys
+ * screen-bounds clamping, scrolling when a category is taller than the display,
+ * Escape/arrow navigation and Qt's sloppy-submenu tracking (no diagonal dead
+ * zone) without reimplementing any of it.
+ */
+class NodePaletteSidebar : public QWidget
+{
+  Q_OBJECT
+
+public:
+  /** @param inventory node type -> slash-separated category path
+   *  @param category_colors top-level category -> accent; unlisted categories
+   *         get a deterministic hue derived from their name
+   */
+  NodePaletteSidebar(const std::map<std::string, std::string> &inventory,
+                     const std::map<std::string, QColor>      &category_colors,
+                     const NodePaletteStyle                   &style,
+                     QWidget                                  *parent = nullptr);
+  ~NodePaletteSidebar() override;
+
+  // --- Style
+  void                    set_style(const NodePaletteStyle &style);
+  const NodePaletteStyle &get_style() const;
+
+  /// Restyle every sidebar alive in this process (settings changed).
+  static void restyle_all(const NodePaletteStyle &style);
+
+  // --- Inspection (also the test surface)
+  QStringList              category_names() const;
+  int                      category_count() const;
+  CategoryRailButton      *button_at(int index) const;
+  QMenu                   *menu_at(int index) const;
+  std::vector<std::string> node_types_at(int index) const;
+  /// Every node type reachable through the rail, sorted.
+  std::vector<std::string> all_node_types() const;
+  QLineEdit               *search_field() const;
+
+  // --- Interaction
+  void open_category(int index);
+  void close_flyout();
+  int  open_category_index() const;
+
+protected:
+  /// Watches the open flyout so moving the pointer back onto the rail switches
+  /// categories: while a QMenu holds the mouse grab the rail buttons never see
+  /// an enter event of their own.
+  bool eventFilter(QObject *watched, QEvent *event) override;
+
+signals:
+  void node_type_selected(const std::string &node_type);
+  void node_type_selected_ctrl(const std::string &node_type);
+  void node_type_selected_shift(const std::string &node_type);
+
+private:
+  void   build_rail(const std::map<std::string, std::string> &inventory);
+  void   setup_search(const std::map<std::string, std::string> &inventory);
+  void   emit_for_type(const QString &node_type);
+  void   apply_menu_style(QMenu *menu, const QColor &accent);
+  QColor accent_for(const QString &category) const;
+
+  std::map<std::string, QColor> category_colors;
+  NodePaletteStyle              style;
+
+  QWidget   *rail = nullptr;
+  QLineEdit *search = nullptr;
+
+  std::vector<CategoryRailButton *>   buttons;
+  std::vector<QPointer<QMenu>>        menus;
+  std::vector<std::vector<std::string>> node_types; // per category, sorted
+
+  /// search display string -> node type
+  std::map<QString, QString> search_index;
+
+  int open_index = -1;
+};
+
+} // namespace hesiod

--- a/Hesiod/include/hesiod/gui/widgets/scrollable_dialog.hpp
+++ b/Hesiod/include/hesiod/gui/widgets/scrollable_dialog.hpp
@@ -1,0 +1,68 @@
+/* Copyright (c) 2026 Otto Link. Distributed under the terms of the GNU General Public
+   License. The full license is in the file LICENSE, distributed with this software. */
+#pragma once
+#include <QDialog>
+#include <QDialogButtonBox>
+#include <QRect>
+#include <QScrollArea>
+
+namespace hesiod
+{
+
+/** @brief A dialog whose content scrolls and which never opens larger than the
+ *  screen.
+ *
+ * A settings pane grows over time and grows again with the interface scale. Put
+ * one straight into a QDialog and the dialog takes its content's size hint: at
+ * 200% on a laptop that is taller than the display, so the bottom rows and the
+ * OK button are off-screen with no way to reach them -- a dialog cannot be
+ * resized past the desktop and the content has no scrollbar of its own.
+ *
+ * So: the content goes inside a widget-resizable QScrollArea, the button box
+ * stays outside it (always reachable, never scrolled away), and the initial size
+ * is clamped to the screen's *available logical* geometry, which is already the
+ * scaled-down rectangle at a high QT_SCALE_FACTOR. Both scrollbars are on
+ * demand, so content that is too wide is pannable rather than clipped.
+ *
+ * Deliberately a widget rather than a helper function: fit_to() takes the
+ * rectangle explicitly so the clamping can be tested against a synthetic screen
+ * instead of whatever monitor the test happens to run on.
+ */
+class ScrollableDialog : public QDialog
+{
+  Q_OBJECT
+
+public:
+  /** @param content taken over by the dialog's scroll area
+   *  @param buttons which standard buttons to show outside the scroll area
+   */
+  ScrollableDialog(QWidget                          *content,
+                   const QString                    &title,
+                   QDialogButtonBox::StandardButtons buttons = QDialogButtonBox::Ok,
+                   QWidget                          *parent = nullptr);
+
+  QScrollArea      *scroll_area() const;
+  QDialogButtonBox *button_box() const;
+  QWidget          *content() const;
+
+  /** @brief Size the dialog to its content, clamped to @p available.
+   *
+   * Leaves a margin so the dialog does not sit flush against the screen edges,
+   * and re-centres it inside @p available if clamping moved it off.
+   */
+  void fit_to(const QRect &available);
+
+  /// The screen rectangle fit_to() would use if called now.
+  QRect available_screen_rect() const;
+
+protected:
+  void showEvent(QShowEvent *event) override;
+
+private:
+  QScrollArea      *scroll = nullptr;
+  QDialogButtonBox *buttons = nullptr;
+  QWidget          *body = nullptr;
+  bool              fitted = false;
+};
+
+} // namespace hesiod

--- a/Hesiod/src/app/app_context.cpp
+++ b/Hesiod/src/app/app_context.cpp
@@ -69,10 +69,26 @@ void AppContext::load_settings()
 {
   Logger::log()->trace("AppContext::load_settings");
 
-  std::string    fname = get_config_file_path_auto("hesiod");
-  nlohmann::json json = json_from_file(fname);
+  std::string fname = get_config_file_path_auto("hesiod");
 
-  this->settings_json_from(json);
+  // A settings file the user cannot open the application to fix is a dead end:
+  // an unparseable number, a truncated write or a type that does not match what
+  // a key expects used to escape all the way out of main() and kill startup
+  // before any window appeared. Fall back to the compiled defaults and say so.
+  try
+  {
+    nlohmann::json json = json_from_file(fname);
+    this->settings_json_from(json);
+  }
+  catch (const std::exception &e)
+  {
+    Logger::log()->error("AppContext::load_settings: could not read the settings "
+                         "file, starting from defaults instead ({}): {}",
+                         fname,
+                         e.what());
+
+    this->reset_settings();
+  }
 }
 
 void AppContext::new_project()

--- a/Hesiod/src/app/app_settings.cpp
+++ b/Hesiod/src/app/app_settings.cpp
@@ -1,6 +1,9 @@
 /* Copyright (c) 2025 Otto Link. Distributed under the terms of the GNU General
  * Public License. The full license is in the file LICENSE, distributed with
  * this software. */
+#include <algorithm>
+#include <cmath>
+
 #include <QBuffer>
 #include <QByteArray>
 #include <QDir>
@@ -13,6 +16,7 @@
 #include "highmap/opencl/gpu_opencl.hpp"
 
 #include "hesiod/app/app_settings.hpp"
+#include "hesiod/app/ui_scale.hpp"
 #include "hesiod/logger.hpp"
 #include "hesiod/model/utils.hpp"
 
@@ -151,6 +155,89 @@ void AppSettings::json_from(nlohmann::json const &json)
   json_safe_get(json,
                 "interface.properties_panel_theme",
                 interface.properties_panel_theme);
+  json_safe_get(json,
+                "interface.enable_node_palette_sidebar",
+                interface.enable_node_palette_sidebar);
+  json_safe_get(json, "interface.enable_ui_animations", interface.enable_ui_animations);
+
+  // The interface scale is the one setting a bad value makes the application
+  // unusable with, so it is read by hand rather than through json_safe_get: a
+  // string, an object or a NaN here has to degrade to 100%, not throw out of
+  // the whole settings load.
+  {
+    interface.ui_scale = ui_scale::kDefault;
+
+    if (json.contains("interface.ui_scale"))
+    {
+      const nlohmann::json &entry = json.at("interface.ui_scale");
+
+      if (entry.is_number())
+      {
+        bool clean = false;
+        interface.ui_scale = ui_scale::sanitize(entry.get<double>(), &clean);
+
+        if (!clean)
+          Logger::log()->warn("AppSettings: interface.ui_scale {} is outside the "
+                              "supported [{}, {}] range, using {}",
+                              entry.dump(),
+                              ui_scale::kMin,
+                              ui_scale::kMax,
+                              interface.ui_scale);
+      }
+      else
+      {
+        Logger::log()->error("AppSettings: interface.ui_scale is not a number ({}), "
+                             "using {}",
+                             entry.type_name(),
+                             ui_scale::kDefault);
+      }
+    }
+  }
+
+  // node palette look; every entry is optional so an older config keeps the
+  // compiled defaults instead of a half-populated style
+  {
+    auto get_color = [&json](const std::string &key, QColor &value)
+    {
+      if (json.contains(key) && json.at(key).is_string())
+      {
+        const QString name = QString::fromStdString(json.at(key).get<std::string>());
+        if (QColor::isValidColorName(name))
+          value = QColor(name);
+      }
+    };
+
+    auto get_metric = [&json](const std::string &key, int &value, int lo, int hi)
+    {
+      if (json.contains(key) && json.at(key).is_number())
+        value = std::clamp(json.at(key).get<int>(), lo, hi);
+    };
+
+    get_color("node_palette.surface", node_palette.surface);
+    get_color("node_palette.surface_hover", node_palette.surface_hover);
+    get_color("node_palette.surface_selected", node_palette.surface_selected);
+    get_color("node_palette.flyout_bg", node_palette.flyout_bg);
+    get_color("node_palette.flyout_border", node_palette.flyout_border);
+    get_color("node_palette.text", node_palette.text);
+    get_color("node_palette.text_active", node_palette.text_active);
+
+    get_metric("node_palette.button_height", node_palette.button_height, 20, 120);
+    get_metric("node_palette.button_spacing", node_palette.button_spacing, 0, 40);
+    get_metric("node_palette.rail_padding", node_palette.rail_padding, 0, 40);
+    get_metric("node_palette.icon_size", node_palette.icon_size, 8, 64);
+    get_metric("node_palette.corner_radius", node_palette.corner_radius, 0, 24);
+    get_metric("node_palette.flyout_row_height", node_palette.flyout_row_height, 14, 80);
+    get_metric("node_palette.flyout_padding", node_palette.flyout_padding, 0, 24);
+    get_metric("node_palette.animation_ms", node_palette.animation_ms, 0, 1000);
+
+    if (json.contains("node_palette.accent_strength") &&
+        json.at("node_palette.accent_strength").is_number())
+    {
+      const double value = json.at("node_palette.accent_strength").get<double>();
+      node_palette.accent_strength = std::isfinite(value) ? std::clamp(value, 0.0, 1.0)
+                                                          : 1.0;
+    }
+  }
 
   // OpenCL device
   {
@@ -271,6 +358,27 @@ nlohmann::json AppSettings::json_to() const
       interface.enable_example_selector_at_startup;
   json["interface.properties_panel_design"] = interface.properties_panel_design;
   json["interface.properties_panel_theme"] = interface.properties_panel_theme;
+  json["interface.ui_scale"] = ui_scale::sanitize(interface.ui_scale);
+  json["interface.enable_node_palette_sidebar"] = interface.enable_node_palette_sidebar;
+  json["interface.enable_ui_animations"] = interface.enable_ui_animations;
+
+  json["node_palette.surface"] = node_palette.surface.name().toStdString();
+  json["node_palette.surface_hover"] = node_palette.surface_hover.name().toStdString();
+  json["node_palette.surface_selected"] = node_palette.surface_selected.name()
+                                              .toStdString();
+  json["node_palette.flyout_bg"] = node_palette.flyout_bg.name().toStdString();
+  json["node_palette.flyout_border"] = node_palette.flyout_border.name().toStdString();
+  json["node_palette.text"] = node_palette.text.name().toStdString();
+  json["node_palette.text_active"] = node_palette.text_active.name().toStdString();
+  json["node_palette.button_height"] = node_palette.button_height;
+  json["node_palette.button_spacing"] = node_palette.button_spacing;
+  json["node_palette.rail_padding"] = node_palette.rail_padding;
+  json["node_palette.icon_size"] = node_palette.icon_size;
+  json["node_palette.corner_radius"] = node_palette.corner_radius;
+  json["node_palette.flyout_row_height"] = node_palette.flyout_row_height;
+  json["node_palette.flyout_padding"] = node_palette.flyout_padding;
+  json["node_palette.animation_ms"] = node_palette.animation_ms;
+  json["node_palette.accent_strength"] = node_palette.accent_strength;
 
   json["node_editor.gpu_device_name"] = node_editor.gpu_device_name;
   json["node_editor.default_resolution"] = node_editor.default_resolution;

--- a/Hesiod/src/app/hesiod_application.cpp
+++ b/Hesiod/src/app/hesiod_application.cpp
@@ -35,6 +35,7 @@
 #include "hesiod/gui/widgets/graph_tabs_widget.hpp"
 #include "hesiod/gui/widgets/gui_utils.hpp"
 #include "hesiod/gui/widgets/project_settings_dialog.hpp"
+#include "hesiod/gui/widgets/scrollable_dialog.hpp"
 #include "hesiod/gui/widgets/splash_screen.hpp"
 #include "hesiod/gui/widgets/tool_tip_blocker.hpp"
 #include "hesiod/logger.hpp"
@@ -110,6 +111,7 @@ HesiodApplication::HesiodApplication(int &argc, char **argv) : QApplication(argc
   // apply style
   this->setWindowIcon(QIcon(this->context.app_settings.global.icon_path.c_str()));
   apply_global_style(this->get_qapp());
+  apply_animation_settings(this->context.app_settings.interface.enable_ui_animations);
 
   // main window
   this->main_window = new MainWindow();
@@ -400,20 +402,15 @@ void HesiodApplication::on_application_settings_action()
 {
   Logger::log()->trace("HesiodApplication::on_application_settings_action");
 
-  // initialize app settings widget
-  AppSettingsWindow *settings_window = new AppSettingsWindow(this->main_window);
+  // The settings pane is long and gets longer with the interface scale, so it
+  // goes in a scrolling dialog capped to the screen; a plain QDialog takes the
+  // pane's full height and pushes OK off the bottom at 200%.
+  AppSettingsWindow *settings_window = new AppSettingsWindow();
 
-  // open in a dialog
-  QDialog dialog(this->main_window);
-  dialog.setWindowTitle("Application Settings");
-
-  QVBoxLayout *layout = new QVBoxLayout(&dialog);
-  layout->addWidget(settings_window);
-
-  QDialogButtonBox *button_box = new QDialogButtonBox(QDialogButtonBox::Ok);
-  button_box->button(QDialogButtonBox::Ok)->setDefault(true);
-  this->connect(button_box, &QDialogButtonBox::accepted, &dialog, &QDialog::accept);
-  layout->addWidget(button_box);
+  ScrollableDialog dialog(settings_window,
+                          "Application Settings",
+                          QDialogButtonBox::Ok,
+                          this->main_window);
 
   dialog.setModal(true);
   dialog.exec();

--- a/Hesiod/src/app/ui_scale.cpp
+++ b/Hesiod/src/app/ui_scale.cpp
@@ -1,0 +1,219 @@
+/* Copyright (c) 2026 Otto Link. Distributed under the terms of the GNU General
+ * Public License. The full license is in the file LICENSE, distributed with
+ * this software. */
+#include <algorithm>
+#include <cmath>
+#include <filesystem>
+#include <fstream>
+
+#include <QByteArray>
+#include <QDir>
+#include <QStandardPaths>
+#include <QtGlobal>
+
+#ifdef Q_OS_WIN
+#define WIN32_LEAN_AND_MEAN
+#define NOMINMAX
+#include <windows.h>
+#endif
+
+#include "nlohmann/json.hpp"
+
+#include "hesiod/app/ui_scale.hpp"
+#include "hesiod/logger.hpp"
+
+namespace fs = std::filesystem;
+
+namespace hesiod::ui_scale
+{
+
+namespace
+{
+Resolution g_session;
+} // namespace
+
+double sanitize(double value, bool *out_was_clean)
+{
+  const bool finite = std::isfinite(value);
+  const bool in_range = finite && value >= kMin && value <= kMax;
+
+  if (out_was_clean)
+    *out_was_clean = in_range;
+
+  if (!finite)
+    return kDefault;
+
+  return std::clamp(value, kMin, kMax);
+}
+
+std::string executable_dir(const char *argv0)
+{
+  std::error_code ec;
+
+#ifdef Q_OS_WIN
+  // argv[0] is whatever the launcher passed: a bare "hesiod.exe" found on PATH,
+  // or a path relative to a working directory that is not the install. Ask the
+  // loader for the real image path instead.
+  {
+    std::wstring buffer(1024, L'\0');
+    const DWORD  length = ::GetModuleFileNameW(nullptr,
+                                              buffer.data(),
+                                              static_cast<DWORD>(buffer.size()));
+
+    // length == size means truncated, which is not a path we should trust
+    if (length > 0 && length < buffer.size())
+    {
+      buffer.resize(length);
+      const fs::path exe(buffer);
+      if (exe.has_parent_path())
+        return exe.parent_path().string();
+    }
+  }
+#endif
+
+  if (argv0 && *argv0)
+  {
+    const fs::path exe = fs::absolute(fs::path(argv0), ec);
+    if (!ec)
+      return exe.parent_path().string();
+  }
+
+  return {};
+}
+
+std::string startup_config_path(const char *argv0)
+{
+  // portable install: a config or a flag file sitting next to the executable
+  std::error_code ec;
+  const fs::path  exe_dir = executable_dir(argv0);
+
+  if (!exe_dir.empty())
+  {
+    const fs::path portable_json = exe_dir / "hesiod.json";
+    const fs::path portable_flag = exe_dir / "portable.flag";
+
+    if (fs::exists(portable_json, ec) || fs::exists(portable_flag, ec))
+      return portable_json.string();
+  }
+
+  // per-user config; QStandardPaths needs the application name, which main()
+  // pins before calling us so this matches what AppContext resolves later
+  QString dir = QStandardPaths::writableLocation(QStandardPaths::AppConfigLocation);
+  if (dir.isEmpty())
+    dir = QStandardPaths::writableLocation(QStandardPaths::AppDataLocation);
+
+  if (dir.isEmpty())
+    return {};
+
+  return (dir + QDir::separator() + "hesiod.json").toStdString();
+}
+
+double scale_from_config(const std::string &config_path)
+{
+  if (config_path.empty())
+    return kDefault;
+
+  std::error_code ec;
+  if (!fs::exists(fs::path(config_path), ec))
+    return kDefault;
+
+  std::ifstream file(config_path);
+  if (!file.is_open())
+    return kDefault;
+
+  nlohmann::json json;
+  try
+  {
+    file >> json;
+  }
+  catch (const std::exception &)
+  {
+    // a corrupt config must not stop the application from starting at 100%
+    return kDefault;
+  }
+
+  if (!json.contains("app_settings"))
+    return kDefault;
+
+  const nlohmann::json &app_settings = json.at("app_settings");
+  if (!app_settings.contains("interface.ui_scale"))
+    return kDefault;
+
+  const nlohmann::json &entry = app_settings.at("interface.ui_scale");
+  if (!entry.is_number())
+    return kDefault; // a string or an object here is not a scale factor
+
+  bool         clean = false;
+  const double value = sanitize(entry.get<double>(), &clean);
+
+  if (!clean)
+    Logger::log()->warn("ui_scale: persisted interface scale {} is out of the "
+                        "supported [{}, {}] range, using {}",
+                        entry.dump(),
+                        kMin,
+                        kMax,
+                        value);
+
+  return value;
+}
+
+Resolution apply_scale(double configured)
+{
+  Resolution result;
+  result.configured = sanitize(configured);
+
+  // An explicit environment override is the user talking to Qt directly. Do not
+  // multiply our factor into it and end up scaled twice -- and do not go on to
+  // claim the preference is active, because it is not.
+  const QByteArray env = qgetenv("QT_SCALE_FACTOR");
+
+  if (!env.isEmpty())
+  {
+    bool         parsed = false;
+    const double value = env.toDouble(&parsed);
+
+    // Qt ignores a factor it cannot parse or that is not positive, so the
+    // process really does run at 1.0 in that case
+    const bool usable = parsed && std::isfinite(value) && value > 0.0;
+
+    result.environment_override = true;
+    result.effective = usable ? value : kDefault;
+
+    Logger::log()->info("ui_scale: QT_SCALE_FACTOR={} is set in the environment; the "
+                        "interface scale setting ({}) is not applied, the process "
+                        "runs at {}",
+                        env.toStdString(),
+                        result.configured,
+                        result.effective);
+
+    g_session = result;
+    return result;
+  }
+
+  result.effective = result.configured;
+  g_session = result;
+
+  if (std::abs(result.effective - kDefault) < 1e-6)
+    return result;
+
+  // Qt multiplies this into the per-monitor DPI factor rather than replacing
+  // it, which is exactly what we want: a 150% monitor stays at 150% and the
+  // user's preference rides on top.
+  qputenv("QT_SCALE_FACTOR", QByteArray::number(result.effective, 'g', 4));
+
+  Logger::log()->info("ui_scale: interface scale {} applied via QT_SCALE_FACTOR",
+                      result.effective);
+
+  return result;
+}
+
+Resolution apply_startup_scale(const char *argv0)
+{
+  return apply_scale(scale_from_config(startup_config_path(argv0)));
+}
+
+Resolution session_resolution() { return g_session; }
+
+double session_scale() { return g_session.effective; }
+
+} // namespace hesiod::ui_scale

--- a/Hesiod/src/app/ui_scale.cpp
+++ b/Hesiod/src/app/ui_scale.cpp
@@ -8,6 +8,7 @@
 
 #include <QByteArray>
 #include <QDir>
+#include <QGuiApplication>
 #include <QStandardPaths>
 #include <QtGlobal>
 
@@ -196,10 +197,31 @@ Resolution apply_scale(double configured)
   if (std::abs(result.effective - kDefault) < 1e-6)
     return result;
 
+  // Qt rounds the *screen* DPI factor before our factor is multiplied in, and
+  // the default policy on X11/Wayland rounds to a whole number. On a 1.0
+  // monitor that is harmless, but the rounded screen factor and the unrounded
+  // product then disagree about how many device pixels a logical pixel is, and
+  // input coordinates are mapped with one while widgets are laid out with the
+  // other -- which is exactly the "cursor lands next to the widget" offset.
+  // PassThrough keeps the screen factor unrounded so the two agree again.
+  //
+  // Set only when we are the ones scaling: a user who pinned the policy
+  // themselves keeps it, and at 1.0 we return above without touching anything.
+  if (!qEnvironmentVariableIsSet("QT_SCALE_FACTOR_ROUNDING_POLICY"))
+    QGuiApplication::setHighDpiScaleFactorRoundingPolicy(
+        Qt::HighDpiScaleFactorRoundingPolicy::PassThrough);
+
   // Qt multiplies this into the per-monitor DPI factor rather than replacing
   // it, which is exactly what we want: a 150% monitor stays at 150% and the
   // user's preference rides on top.
-  qputenv("QT_SCALE_FACTOR", QByteArray::number(result.effective, 'g', 4));
+  //
+  // 'f' with a fixed precision, never 'g': 'g' can emit an exponent form, and
+  // the C locale is not guaranteed here -- a comma decimal separator parses as
+  // a truncated integer inside Qt, which silently scales by 0 or 9 instead of
+  // 0.9.
+  QByteArray factor = QByteArray::number(result.effective, 'f', 4);
+  factor.replace(',', '.');
+  qputenv("QT_SCALE_FACTOR", factor);
 
   Logger::log()->info("ui_scale: interface scale {} applied via QT_SCALE_FACTOR",
                       result.effective);

--- a/Hesiod/src/gui/utils/gui_utils.cpp
+++ b/Hesiod/src/gui/utils/gui_utils.cpp
@@ -10,12 +10,42 @@
 #include <QWidget>
 #include <QWidgetAction>
 
+#include <QApplication>
+
+#include "hesiod/app/hesiod_application.hpp"
 #include "hesiod/gui/widgets/gui_utils.hpp"
+#include "hesiod/gui/widgets/node_palette_sidebar.hpp"
 #include "hesiod/logger.hpp"
 #include "hesiod/model/utils.hpp"
 
 namespace hesiod
 {
+
+void apply_animation_settings(bool enabled)
+{
+  Logger::log()->trace("apply_animation_settings: {}", enabled);
+
+  for (const Qt::UIEffect effect : {Qt::UI_AnimateMenu,
+                                    Qt::UI_FadeMenu,
+                                    Qt::UI_AnimateCombo,
+                                    Qt::UI_AnimateTooltip,
+                                    Qt::UI_FadeTooltip,
+                                    Qt::UI_AnimateToolBox})
+    QApplication::setEffectEnabled(effect, enabled);
+
+  // reach the sidebars that already exist: a motion setting that only applies
+  // to widgets created later looks like it did nothing
+  NodePaletteStyle style = current_node_palette_style();
+  style.animations = enabled;
+  NodePaletteSidebar::restyle_all(style);
+}
+
+NodePaletteStyle current_node_palette_style()
+{
+  NodePaletteStyle style = HSD_CTX.app_settings.node_palette;
+  style.animations = HSD_CTX.app_settings.interface.enable_ui_animations;
+  return style;
+}
 
 void add_qmenu_spacer(QMenu *menu, int height)
 {

--- a/Hesiod/src/gui/widgets/app_settings_window.cpp
+++ b/Hesiod/src/gui/widgets/app_settings_window.cpp
@@ -1,14 +1,22 @@
 /* Copyright (c) 2025 Otto Link. Distributed under the terms of the GNU General
  * Public License. The full license is in the file LICENSE, distributed with
  * this software. */
+#include <algorithm>
+#include <cmath>
+
 #include <QColorDialog>
+#include <QDoubleSpinBox>
 #include <QFormLayout>
+#include <QHBoxLayout>
+#include <QLabel>
 #include <QMessageBox>
 #include <QPushButton>
 
 #include "hesiod/app/hesiod_application.hpp"
+#include "hesiod/app/ui_scale.hpp"
 #include "hesiod/gui/widgets/app_settings_window.hpp"
 #include "hesiod/gui/widgets/gui_utils.hpp"
+#include "hesiod/gui/widgets/node_palette_sidebar.hpp"
 #include "hesiod/logger.hpp"
 #include "hesiod/model/utils.hpp"
 
@@ -29,6 +37,8 @@ void AppSettingsWindow::add_description(const std::string &description, int max_
     return;
 
   QLabel *label = new QLabel(wrap_text(description, max_length).c_str());
+  label->setWordWrap(true); // a pre-wrapped line still has to reflow when the
+                            // dialog is narrower than the text it was wrapped for
 
   std::string style = std::format(
       "color: {};",
@@ -73,7 +83,9 @@ void AppSettingsWindow::bind_int(const std::string &label, int &value)
   this->layout->addRow(label.c_str(), spin_box);
 }
 
-void AppSettingsWindow::bind_bool(const std::string &label, bool &state)
+void AppSettingsWindow::bind_bool(const std::string        &label,
+                                  bool                     &state,
+                                  std::function<void(bool)> on_changed)
 {
   auto *check_box = new QCheckBox();
   check_box->setChecked(state);
@@ -81,9 +93,47 @@ void AppSettingsWindow::bind_bool(const std::string &label, bool &state)
   this->connect(check_box,
                 &QCheckBox::toggled,
                 this,
-                [&state](bool value) { state = value; });
+                [&state, on_changed](bool value)
+                {
+                  state = value;
+                  if (on_changed)
+                    on_changed(value);
+                });
 
   this->layout->addRow(label.c_str(), check_box);
+}
+
+void AppSettingsWindow::bind_int_range(const std::string &label,
+                                       int               &value,
+                                       int                min,
+                                       int                max,
+                                       const std::string &suffix)
+{
+  auto *spin_box = new QSpinBox();
+  spin_box->setRange(min, max);
+  spin_box->setValue(std::clamp(value, min, max));
+  spin_box->setSuffix(suffix.c_str());
+
+  this->connect(spin_box,
+                QOverload<int>::of(&QSpinBox::valueChanged),
+                this,
+                [this, &value](int v)
+                {
+                  value = v;
+                  NodePaletteSidebar::restyle_all(current_node_palette_style());
+                });
+
+  this->layout->addRow(label.c_str(), spin_box);
+}
+
+void AppSettingsWindow::refresh_theme()
+{
+  // colours reach three places: the global stylesheet and palette, the icons
+  // (re-tinted inside apply_global_style) and any open palette sidebar
+  if (auto *app = qobject_cast<QApplication *>(QCoreApplication::instance()))
+    apply_global_style(*app);
+
+  NodePaletteSidebar::restyle_all(current_node_palette_style());
 }
 
 void AppSettingsWindow::bind_qcolor(const std::string &label, QColor &color)
@@ -112,9 +162,98 @@ void AppSettingsWindow::bind_qcolor(const std::string &label, QColor &color)
         color = new_color;
         button->setStyleSheet(
             QString("background-color: %1; border: 1px solid #444;").arg(color.name()));
+
+        this->refresh_theme();
       });
 
   this->layout->addRow(label.c_str(), button);
+}
+
+void AppSettingsWindow::setup_interface_scale_row()
+{
+  AppContext &ctx = HSD_CTX;
+
+  auto *spin_box = new QDoubleSpinBox();
+  spin_box->setRange(ui_scale::kMin, ui_scale::kMax);
+  spin_box->setSingleStep(ui_scale::kStep);
+  spin_box->setDecimals(2);
+  spin_box->setSuffix(" x");
+  spin_box->setValue(ui_scale::sanitize(ctx.app_settings.interface.ui_scale));
+  spin_box->setToolTip("Scales the whole interface: text, icons, spacing and "
+                       "controls. Multiplied with the monitor's own scaling "
+                       "rather than replacing it.");
+
+  auto *reset_button = new QPushButton("Reset");
+  reset_button->setToolTip("Back to 1.00x");
+
+  auto *note = new QLabel();
+  note->setWordWrap(true);
+  resize_font(note, -1);
+
+  auto update_note = [note, &ctx]()
+  {
+    const double configured = ui_scale::sanitize(ctx.app_settings.interface.ui_scale);
+    const ui_scale::Resolution session = ui_scale::session_resolution();
+    const double               running = session.effective;
+
+    QString text;
+    bool    highlight = false;
+
+    if (session.environment_override)
+    {
+      // Saying "restart to apply" here would be a lie: Qt is obeying the
+      // environment and a restart changes nothing until that variable is gone.
+      text = QString("QT_SCALE_FACTOR is set in this process's environment, so "
+                     "Hesiod is running at %1x and this setting is not being "
+                     "applied. Clear that variable to use the setting.")
+                 .arg(running, 0, 'f', 2);
+      highlight = true;
+    }
+    else if (std::abs(configured - running) > 1e-6)
+    {
+      text = QString("Running at %1x. Restart Hesiod to apply %2x.")
+                 .arg(running, 0, 'f', 2)
+                 .arg(configured, 0, 'f', 2);
+      highlight = true;
+    }
+    else
+    {
+      text = QString("Running at %1x.").arg(running, 0, 'f', 2);
+    }
+
+    note->setText(text);
+    note->setStyleSheet(
+        QString("color: %1;")
+            .arg(highlight ? ctx.app_settings.colors.accent.name()
+                           : ctx.app_settings.colors.text_secondary.name()));
+  };
+
+  update_note();
+
+  this->connect(spin_box,
+                QOverload<double>::of(&QDoubleSpinBox::valueChanged),
+                this,
+                [&ctx, update_note](double value)
+                {
+                  // store the sanitized absolute value, never a delta: two
+                  // changes in a row must land where a single jump would
+                  ctx.app_settings.interface.ui_scale = ui_scale::sanitize(value);
+                  update_note();
+                });
+
+  this->connect(reset_button,
+                &QPushButton::clicked,
+                this,
+                [spin_box]() { spin_box->setValue(ui_scale::kDefault); });
+
+  auto *row = new QWidget();
+  auto *row_layout = new QHBoxLayout(row);
+  row_layout->setContentsMargins(0, 0, 0, 0);
+  row_layout->addWidget(spin_box, 1);
+  row_layout->addWidget(reset_button, 0);
+
+  this->layout->addRow("Interface scale", row);
+  this->layout->addRow(note);
 }
 
 void AppSettingsWindow::setup_layout()
@@ -125,6 +264,12 @@ void AppSettingsWindow::setup_layout()
 
   this->layout = new QFormLayout(this);
   this->layout->setHorizontalSpacing(24);
+
+  // At a large interface scale the label column plus its field no longer fit
+  // side by side; without this the form just gets wider than the screen and the
+  // controls go off the right edge instead of stacking under their labels.
+  this->layout->setRowWrapPolicy(QFormLayout::WrapLongRows);
+  this->layout->setFieldGrowthPolicy(QFormLayout::AllNonFixedFieldsGrow);
 
   {
     QLabel *label = new QLabel;
@@ -161,6 +306,73 @@ void AppSettingsWindow::setup_layout()
                   ctx.app_settings.interface.enable_texture_downloader);
   this->bind_bool("Enable example selector at startup",
                   ctx.app_settings.interface.enable_example_selector_at_startup);
+
+  this->bind_bool("Enable interface animations",
+                  ctx.app_settings.interface.enable_ui_animations,
+                  [](bool enabled) { apply_animation_settings(enabled); });
+
+  this->add_description("\n");
+
+  // --- Interface scale
+
+  this->add_title("Interface Scale");
+  this->setup_interface_scale_row();
+
+  this->add_description("\n");
+
+  // --- Node palette sidebar
+
+  this->add_title("Node Palette Sidebar");
+
+  this->add_description("An alternative to the node library tree: a category "
+                        "rail with hierarchical flyout menus. Takes effect on the "
+                        "next restart.");
+
+  this->bind_bool("Use the category rail instead of the library tree",
+                  ctx.app_settings.interface.enable_node_palette_sidebar);
+
+  this->bind_qcolor("Category button", ctx.app_settings.node_palette.surface);
+  this->bind_qcolor("Category button (hovered)",
+                    ctx.app_settings.node_palette.surface_hover);
+  this->bind_qcolor("Category button (open)",
+                    ctx.app_settings.node_palette.surface_selected);
+  this->bind_qcolor("Flyout background", ctx.app_settings.node_palette.flyout_bg);
+  this->bind_qcolor("Flyout border", ctx.app_settings.node_palette.flyout_border);
+  this->bind_qcolor("Label", ctx.app_settings.node_palette.text);
+  this->bind_qcolor("Label (active)", ctx.app_settings.node_palette.text_active);
+
+  this->bind_int_range("Category button height",
+                       ctx.app_settings.node_palette.button_height,
+                       20,
+                       120);
+  this->bind_int_range("Category button spacing",
+                       ctx.app_settings.node_palette.button_spacing,
+                       0,
+                       40);
+  this->bind_int_range("Rail padding", ctx.app_settings.node_palette.rail_padding, 0, 40);
+  this->bind_int_range("Category icon size",
+                       ctx.app_settings.node_palette.icon_size,
+                       8,
+                       64);
+  this->bind_int_range("Corner radius",
+                       ctx.app_settings.node_palette.corner_radius,
+                       0,
+                       24);
+  this->bind_int_range("Flyout row height",
+                       ctx.app_settings.node_palette.flyout_row_height,
+                       14,
+                       80);
+  this->bind_int_range("Flyout padding",
+                       ctx.app_settings.node_palette.flyout_padding,
+                       0,
+                       24);
+  this->bind_int_range("Animation duration",
+                       ctx.app_settings.node_palette.animation_ms,
+                       0,
+                       1000,
+                       " ms");
+
+  this->add_description("\n");
 
   this->add_title("Node Editor");
 

--- a/Hesiod/src/gui/widgets/graph_editor_widget.cpp
+++ b/Hesiod/src/gui/widgets/graph_editor_widget.cpp
@@ -13,7 +13,9 @@
 #include "hesiod/gui/widgets/grip_splitter.hpp"
 #include "hesiod/gui/widgets/gui_utils.hpp"
 #include "hesiod/gui/widgets/node_library_widget.hpp"
+#include "hesiod/gui/widgets/node_palette_sidebar.hpp"
 #include "hesiod/gui/widgets/node_settings_widget.hpp"
+#include "hesiod/model/nodes/node_factory.hpp"
 #include "hesiod/gui/widgets/viewers/viewer_3d.hpp"
 #include "hesiod/logger.hpp"
 #include "hesiod/model/graph/graph_node.hpp"
@@ -108,6 +110,14 @@ void GraphEditorWidget::set_node_library_visible(bool new_state)
   if (this->node_library_widget)
     this->node_library_widget->setVisible(new_state);
 
+  if (this->node_palette_sidebar)
+  {
+    // a hidden rail must not leave its flyout floating over the graph
+    if (!new_state)
+      this->node_palette_sidebar->close_flyout();
+    this->node_palette_sidebar->setVisible(new_state);
+  }
+
   // arrow points at the panel's collapse direction
   if (this->node_library_toggle_button)
     this->node_library_toggle_button->setArrowType(new_state ? Qt::LeftArrow
@@ -156,8 +166,19 @@ void GraphEditorWidget::setup_layout()
       layout->addWidget(this->node_library_toggle_button, 0, 0, 2, 1);
     }
 
-    this->node_library_widget = new NodeLibraryWidget();
-    layout->addWidget(this->node_library_widget, 0, 1, 2, 1);
+    if (HSD_CTX.app_settings.interface.enable_node_palette_sidebar)
+    {
+      this->node_palette_sidebar = new NodePaletteSidebar(
+          get_node_inventory(),
+          HSD_CTX.style_settings.category_color_map,
+          current_node_palette_style());
+      layout->addWidget(this->node_palette_sidebar, 0, 1, 2, 1);
+    }
+    else
+    {
+      this->node_library_widget = new NodeLibraryWidget();
+      layout->addWidget(this->node_library_widget, 0, 1, 2, 1);
+    }
 
     this->set_node_library_visible(
         HSD_CTX.app_settings.node_editor.show_node_library_pan);
@@ -253,12 +274,37 @@ void GraphEditorWidget::setup_layout()
                   this->graph_node_widget,
                   &GraphNodeWidget::on_new_node_request_replace);
 
-    if (this->node_library_toggle_button)
-      this->connect(this->node_library_toggle_button,
-                    &QToolButton::clicked,
-                    this,
-                    [this]() { Q_EMIT this->node_library_toggle_requested(); });
   }
+
+  // the palette sidebar creates nodes through exactly the same slots as the
+  // library tree, so the two cannot drift apart
+  if (this->node_palette_sidebar)
+  {
+    this->connect(this->node_palette_sidebar,
+                  &NodePaletteSidebar::node_type_selected,
+                  this->graph_node_widget,
+                  [this](const std::string &node_type)
+                  {
+                    QPointF center = this->graph_node_widget->get_center();
+                    this->graph_node_widget->on_new_node_request(node_type, center);
+                  });
+
+    this->connect(this->node_palette_sidebar,
+                  &NodePaletteSidebar::node_type_selected_shift,
+                  this->graph_node_widget,
+                  &GraphNodeWidget::on_new_node_request_chain);
+
+    this->connect(this->node_palette_sidebar,
+                  &NodePaletteSidebar::node_type_selected_ctrl,
+                  this->graph_node_widget,
+                  &GraphNodeWidget::on_new_node_request_replace);
+  }
+
+  if (this->node_library_toggle_button)
+    this->connect(this->node_library_toggle_button,
+                  &QToolButton::clicked,
+                  this,
+                  [this]() { Q_EMIT this->node_library_toggle_requested(); });
 }
 
 } // namespace hesiod

--- a/Hesiod/src/gui/widgets/graph_editor_widget.cpp
+++ b/Hesiod/src/gui/widgets/graph_editor_widget.cpp
@@ -1,6 +1,8 @@
 /* Copyright (c) 2025 Otto Link. Distributed under the terms of the GNU General
  * Public License. The full license is in the file LICENSE, distributed with
  * this software. */
+#include <algorithm>
+
 #include <QGridLayout>
 #include <QSplitter>
 #include <QTimer>
@@ -233,7 +235,27 @@ void GraphEditorWidget::setup_layout()
   h_splitter->addWidget(this->node_settings_widget);
   h_splitter->setStretchFactor(0, 1); // graph area absorbs window resizing
   h_splitter->setStretchFactor(1, 0); // settings keeps its width
-  h_splitter->setSizes({650, HSD_CTX.app_settings.node_editor.node_settings_panel_width});
+  // Both numbers are logical pixels, and the graph half is a constant while the
+  // settings half comes from a file written at whatever scale the user ran
+  // last. QSplitter distributes its *actual* width in proportion to these, so
+  // the pair only has to be a ratio -- but a saved width that is wide relative
+  // to the window (a panel dragged wide at 100%, reopened in a window that is
+  // narrower in logical pixels after a scale change) starves the graph, and one
+  // that is small relative to a constant 650 collapses the settings pane to
+  // nothing. Clamp the settings share against the width the splitter will
+  // really get, so neither pane can be squeezed out by a stale number.
+  {
+    const int saved = HSD_CTX.app_settings.node_editor.node_settings_panel_width;
+
+    // width() is not final before the first show; fall back to the sum so the
+    // ratio is still sane, and let the clamp below do the rest
+    const int total = h_splitter->width() > 0 ? h_splitter->width() : 650 + saved;
+
+    // never less than a usable panel, never more than half the splitter
+    const int settings = std::clamp(saved, 200, std::max(200, total / 2));
+
+    h_splitter->setSizes({std::max(200, total - settings), settings});
+  }
 
   this->connect(h_splitter,
                 &QSplitter::splitterMoved,

--- a/Hesiod/src/gui/widgets/main_window.cpp
+++ b/Hesiod/src/gui/widgets/main_window.cpp
@@ -68,6 +68,12 @@ void MainWindow::restore_geometry()
   {
     const QRect available = screen->availableGeometry();
 
+    // A geometry that is not usable at all is a stale one, not a preference:
+    // fall back to a comfortable fraction of the screen rather than restoring a
+    // sliver. Guards a config written before the window ever had a real size.
+    if (geom.width() < 320 || geom.height() < 240)
+      geom.setSize(QSize(available.width() * 3 / 4, available.height() * 3 / 4));
+
     geom.setSize(geom.size().boundedTo(available.size()));
     geom.moveLeft(std::clamp(geom.left(), available.left(), available.right() -
                                                                 geom.width() + 1));

--- a/Hesiod/src/gui/widgets/main_window.cpp
+++ b/Hesiod/src/gui/widgets/main_window.cpp
@@ -1,7 +1,11 @@
 /* Copyright (c) 2025 Otto Link. Distributed under the terms of the GNU General
  * Public License. The full license is in the file LICENSE, distributed with
  * this software. */
+#include <algorithm>
+
+#include <QGuiApplication>
 #include <QMessageBox>
+#include <QScreen>
 #include <QStatusBar>
 
 #include "hesiod/app/hesiod_application.hpp"
@@ -47,10 +51,31 @@ void MainWindow::restore_geometry()
 
   AppContext &ctx = HSD_CTX;
 
-  this->setGeometry(ctx.app_settings.window.geom_main.x,
-                    ctx.app_settings.window.geom_main.y,
-                    ctx.app_settings.window.geom_main.w,
-                    ctx.app_settings.window.geom_main.h);
+  QRect geom(ctx.app_settings.window.geom_main.x,
+             ctx.app_settings.window.geom_main.y,
+             ctx.app_settings.window.geom_main.w,
+             ctx.app_settings.window.geom_main.h);
+
+  // Saved geometry is in logical pixels, and raising the interface scale
+  // shrinks the screen measured in those: a window saved full-screen at 100%
+  // is larger than the whole desktop at 200%, with its title bar off the top
+  // and no way to drag it back. Clamp to whatever screen it lands on.
+  const QScreen *screen = QGuiApplication::screenAt(geom.center());
+  if (!screen)
+    screen = QGuiApplication::primaryScreen();
+
+  if (screen)
+  {
+    const QRect available = screen->availableGeometry();
+
+    geom.setSize(geom.size().boundedTo(available.size()));
+    geom.moveLeft(std::clamp(geom.left(), available.left(), available.right() -
+                                                                geom.width() + 1));
+    geom.moveTop(
+        std::clamp(geom.top(), available.top(), available.bottom() - geom.height() + 1));
+  }
+
+  this->setGeometry(geom);
 }
 
 void MainWindow::save_geometry() const

--- a/Hesiod/src/gui/widgets/node_library_widget.cpp
+++ b/Hesiod/src/gui/widgets/node_library_widget.cpp
@@ -144,7 +144,7 @@ void NodeLibraryWidget::setup_layout()
 
   this->tree_widget->setHeaderHidden(true);
   this->tree_widget->setIndentation(12);
-  this->tree_widget->setAnimated(true);
+  this->tree_widget->setAnimated(HSD_CTX.app_settings.interface.enable_ui_animations);
   this->tree_widget->setSelectionMode(QAbstractItemView::NoSelection);
   this->tree_widget->header()->setStretchLastSection(true);
   this->tree_widget->header()->setSectionResizeMode(0, QHeaderView::Stretch);

--- a/Hesiod/src/gui/widgets/node_palette_sidebar.cpp
+++ b/Hesiod/src/gui/widgets/node_palette_sidebar.cpp
@@ -1,0 +1,902 @@
+/* Copyright (c) 2026 Otto Link. Distributed under the terms of the GNU General
+ * Public License. The full license is in the file LICENSE, distributed with
+ * this software. */
+#include <algorithm>
+#include <cmath>
+#include <functional>
+#include <set>
+
+namespace
+{
+constexpr double kPi = 3.14159265358979323846;
+}
+
+
+#include <QApplication>
+#include <QCompleter>
+#include <QEnterEvent>
+#include <QFontMetrics>
+#include <QMouseEvent>
+#include <QPainter>
+#include <QPainterPath>
+#include <QScreen>
+#include <QScrollArea>
+#include <QStringListModel>
+#include <QTimer>
+#include <QVBoxLayout>
+
+#include "hesiod/gui/widgets/node_palette_sidebar.hpp"
+
+namespace hesiod
+{
+
+namespace
+{
+
+/// Sidebars alive in this process, so a settings change can reach open windows.
+std::set<NodePaletteSidebar *> &live_sidebars()
+{
+  static std::set<NodePaletteSidebar *> instances;
+  return instances;
+}
+
+QStringList split_path(const QString &path)
+{
+  return path.split('/', Qt::SkipEmptyParts);
+}
+
+QColor blend(const QColor &a, const QColor &b, double t)
+{
+  t = std::clamp(t, 0.0, 1.0);
+  return QColor(static_cast<int>(a.red() * (1.0 - t) + b.red() * t),
+                static_cast<int>(a.green() * (1.0 - t) + b.green() * t),
+                static_cast<int>(a.blue() * (1.0 - t) + b.blue() * t));
+}
+
+/** @brief A readable accent for a category that the palette does not name.
+ *
+ * Hashing the name keeps it stable across runs and across machines, which
+ * matters because the accent is the only thing distinguishing two rail buttons
+ * at a glance. Saturation and lightness are pinned so no category can come out
+ * muddy or neon.
+ */
+QColor derived_accent(const QString &category)
+{
+  uint hash = 2166136261u;
+  for (const QChar c : category)
+    hash = (hash ^ static_cast<uint>(c.unicode())) * 16777619u;
+
+  return QColor::fromHsl(static_cast<int>(hash % 360u), 110, 150);
+}
+
+/** @brief One of eight line glyphs, picked deterministically from the name.
+ *
+ * Hesiod ships no per-category artwork and inventing forty SVGs for a togglable
+ * sidebar is not worth it. Drawing them keeps the set consistent, scales with
+ * the interface scale for free, and stays distinguishable because the shape is
+ * a stable function of the category name.
+ */
+void draw_glyph(QPainter &painter, const QRectF &box, const QColor &color, int shape)
+{
+  painter.save();
+  painter.setRenderHint(QPainter::Antialiasing, true);
+
+  QPen pen(color);
+  pen.setWidthF(std::max(1.2, box.width() * 0.09));
+  pen.setCapStyle(Qt::RoundCap);
+  pen.setJoinStyle(Qt::RoundJoin);
+  painter.setPen(pen);
+  painter.setBrush(Qt::NoBrush);
+
+  const QPointF c = box.center();
+  const double  r = box.width() * 0.5;
+
+  switch (shape % 8)
+  {
+  case 0: // hexagon
+  {
+    QPolygonF poly;
+    for (int i = 0; i < 6; ++i)
+    {
+      const double a = kPi / 6.0 + i * kPi / 3.0;
+      poly << QPointF(c.x() + r * std::cos(a), c.y() + r * std::sin(a));
+    }
+    painter.drawPolygon(poly);
+    break;
+  }
+  case 1: // ring with a core
+    painter.drawEllipse(c, r, r);
+    painter.setBrush(color);
+    painter.drawEllipse(c, r * 0.22, r * 0.22);
+    break;
+  case 2: // waves
+  {
+    QPainterPath path;
+    path.moveTo(box.left(), c.y() - r * 0.35);
+    path.cubicTo(box.left() + box.width() * 0.33,
+                 c.y() - r * 1.1,
+                 box.left() + box.width() * 0.66,
+                 c.y() + r * 0.4,
+                 box.right(),
+                 c.y() - r * 0.35);
+    painter.drawPath(path);
+    painter.translate(0, r * 0.7);
+    painter.drawPath(path);
+    break;
+  }
+  case 3: // ridge / triangle
+  {
+    QPolygonF poly;
+    poly << QPointF(box.left(), box.bottom()) << QPointF(c.x(), box.top())
+         << QPointF(box.right(), box.bottom());
+    painter.drawPolyline(poly);
+    break;
+  }
+  case 4: // grid
+    for (int i = 0; i <= 2; ++i)
+    {
+      const double t = box.left() + box.width() * i * 0.5;
+      painter.drawLine(QPointF(t, box.top()), QPointF(t, box.bottom()));
+      const double u = box.top() + box.height() * i * 0.5;
+      painter.drawLine(QPointF(box.left(), u), QPointF(box.right(), u));
+    }
+    break;
+  case 5: // droplet
+  {
+    QPainterPath path;
+    path.moveTo(c.x(), box.top());
+    path.quadTo(box.right(), c.y(), c.x(), box.bottom());
+    path.quadTo(box.left(), c.y(), c.x(), box.top());
+    painter.drawPath(path);
+    break;
+  }
+  case 6: // scatter
+    painter.setBrush(color);
+    painter.setPen(Qt::NoPen);
+    for (const QPointF &p : {QPointF(-0.5, -0.4),
+                             QPointF(0.45, -0.15),
+                             QPointF(-0.15, 0.5),
+                             QPointF(0.2, 0.2),
+                             QPointF(-0.45, 0.1)})
+      painter.drawEllipse(QPointF(c.x() + p.x() * r * 1.6, c.y() + p.y() * r * 1.6),
+                          r * 0.16,
+                          r * 0.16);
+    break;
+  default: // node / connector
+    painter.drawLine(QPointF(box.left(), c.y()), QPointF(box.right(), c.y()));
+    painter.drawEllipse(QPointF(box.left() + r * 0.3, c.y()), r * 0.28, r * 0.28);
+    painter.drawEllipse(QPointF(box.right() - r * 0.3, c.y()), r * 0.28, r * 0.28);
+    break;
+  }
+
+  painter.restore();
+}
+
+/** @brief Force a shown popup inside @p available.
+ *
+ * QMenu positions itself on the screen, but a menu with more entries than the
+ * display is tall is laid out in columns first, and that layout overshoots by
+ * the frame width -- measured at every scale from 0.5x to 3x, the last column
+ * ended up 13 to 88 logical pixels below the bottom of the screen. With
+ * `menu-scrollable` on, shrinking it here turns the overflow into scroll arrows
+ * instead of clipped entries.
+ */
+void clamp_to_screen(QMenu *menu, const QRect &available)
+{
+  // setGeometry() below produces move/resize events that come straight back
+  // here; one pass is always enough, so refuse to re-enter rather than relying
+  // on the rectangle happening to be a fixed point
+  static bool clamping = false;
+  if (clamping)
+    return;
+
+  QRect geom = menu->geometry();
+
+  geom.setSize(geom.size().boundedTo(available.size()));
+
+  if (geom.bottom() > available.bottom())
+    geom.moveBottom(available.bottom());
+  if (geom.top() < available.top())
+    geom.moveTop(available.top());
+  if (geom.right() > available.right())
+    geom.moveRight(available.right());
+  if (geom.left() < available.left())
+    geom.moveLeft(available.left());
+
+  if (geom == menu->geometry())
+    return;
+
+  clamping = true;
+  menu->setGeometry(geom);
+  clamping = false;
+}
+
+int glyph_shape_for(const QString &category)
+{
+  uint hash = 2166136261u;
+  for (const QChar c : category)
+    hash = (hash ^ static_cast<uint>(c.unicode())) * 16777619u;
+  return static_cast<int>(hash % 8u);
+}
+
+} // namespace
+
+// =====================================
+// CategoryRailButton
+// =====================================
+
+CategoryRailButton::CategoryRailButton(const QString          &category,
+                                       const QColor           &accent,
+                                       const NodePaletteStyle &style,
+                                       QWidget                *parent)
+    : QAbstractButton(parent), category(category), accent(accent), style(style)
+{
+  this->setText(category);
+  this->setCursor(Qt::PointingHandCursor);
+  this->setFocusPolicy(Qt::TabFocus);
+  this->setSizePolicy(QSizePolicy::Preferred, QSizePolicy::Fixed);
+  this->setAttribute(Qt::WA_Hover, true);
+
+  this->surface = this->style.surface;
+
+  this->surface_animation.setEasingCurve(QEasingCurve::OutCubic);
+  this->connect(&this->surface_animation,
+                &QVariantAnimation::valueChanged,
+                this,
+                [this](const QVariant &value)
+                {
+                  this->surface = value.value<QColor>();
+                  this->update();
+                });
+}
+
+QColor CategoryRailButton::current_surface() const { return this->surface; }
+
+void CategoryRailButton::enterEvent(QEnterEvent *event)
+{
+  this->hovering = true;
+  this->retarget_surface();
+  Q_EMIT this->hovered();
+  QAbstractButton::enterEvent(event);
+}
+
+bool CategoryRailButton::is_open() const { return this->open; }
+
+void CategoryRailButton::leaveEvent(QEvent *event)
+{
+  this->hovering = false;
+  this->retarget_surface();
+  QAbstractButton::leaveEvent(event);
+}
+
+void CategoryRailButton::paintEvent(QPaintEvent *)
+{
+  QPainter painter(this);
+  painter.setRenderHint(QPainter::Antialiasing, true);
+
+  const QRectF box = QRectF(this->rect()).adjusted(0.5, 0.5, -0.5, -0.5);
+
+  painter.setPen(Qt::NoPen);
+  painter.setBrush(this->surface);
+  painter.drawRoundedRect(box, this->style.corner_radius, this->style.corner_radius);
+
+  // the accent only ever touches the glyph and a hairline, never the surface:
+  // a full-width category colour is what makes the old tree hard to read
+  if (this->open || this->hovering)
+  {
+    QPen pen(blend(this->accent, this->style.surface_selected, 0.35));
+    pen.setWidthF(1.0);
+    painter.setPen(pen);
+    painter.setBrush(Qt::NoBrush);
+    painter.drawRoundedRect(box, this->style.corner_radius, this->style.corner_radius);
+  }
+
+  const double icon = this->style.icon_size;
+  const double pad = this->style.rail_padding;
+
+  const QRectF glyph_box(box.left() + pad,
+                         box.center().y() - icon * 0.5,
+                         icon,
+                         icon);
+
+  const QColor glyph_color = blend(this->style.text,
+                                   this->accent,
+                                   this->style.accent_strength);
+  draw_glyph(painter,
+             glyph_box.adjusted(icon * 0.12, icon * 0.12, -icon * 0.12, -icon * 0.12),
+             glyph_color,
+             glyph_shape_for(this->category));
+
+  QFont font = this->font();
+  font.setBold(this->open);
+  painter.setFont(font);
+  painter.setPen(this->open || this->hovering ? this->style.text_active
+                                              : this->style.text);
+
+  const QRectF text_box(glyph_box.right() + pad,
+                        box.top(),
+                        box.right() - glyph_box.right() - 2.0 * pad,
+                        box.height());
+
+  const QString elided = QFontMetrics(font).elidedText(this->category,
+                                                       Qt::ElideRight,
+                                                       static_cast<int>(
+                                                           text_box.width()));
+  painter.drawText(text_box, Qt::AlignVCenter | Qt::AlignLeft, elided);
+}
+
+void CategoryRailButton::retarget_surface()
+{
+  const QColor target = this->target_surface();
+
+  if (this->surface == target)
+    return;
+
+  if (!this->style.animations || this->style.animation_ms <= 0)
+  {
+    // "off" has to mean off *now*, not after the current fade finishes
+    this->surface_animation.stop();
+    this->surface = target;
+    this->update();
+    return;
+  }
+
+  this->surface_animation.stop();
+  this->surface_animation.setDuration(this->style.animation_ms);
+  this->surface_animation.setStartValue(this->surface);
+  this->surface_animation.setEndValue(target);
+  this->surface_animation.start();
+}
+
+void CategoryRailButton::set_open(bool state)
+{
+  if (this->open == state)
+    return;
+
+  this->open = state;
+  this->retarget_surface();
+  this->update();
+}
+
+void CategoryRailButton::set_style(const NodePaletteStyle &new_style)
+{
+  this->style = new_style;
+  this->surface_animation.stop();
+  this->surface = this->target_surface();
+  this->updateGeometry();
+  this->update();
+}
+
+QSize CategoryRailButton::sizeHint() const
+{
+  const int text_w = QFontMetrics(this->font()).horizontalAdvance(this->category);
+  return QSize(3 * this->style.rail_padding + this->style.icon_size + text_w,
+               this->style.button_height);
+}
+
+QColor CategoryRailButton::target_surface() const
+{
+  if (this->open)
+    return this->style.surface_selected;
+  if (this->hovering)
+    return this->style.surface_hover;
+  return this->style.surface;
+}
+
+// =====================================
+// NodePaletteSidebar
+// =====================================
+
+NodePaletteSidebar::NodePaletteSidebar(
+    const std::map<std::string, std::string> &inventory,
+    const std::map<std::string, QColor>      &category_colors,
+    const NodePaletteStyle                   &style,
+    QWidget                                  *parent)
+    : QWidget(parent), category_colors(category_colors), style(style)
+{
+  live_sidebars().insert(this);
+
+  auto *layout = new QVBoxLayout(this);
+  layout->setContentsMargins(this->style.rail_padding,
+                             this->style.rail_padding,
+                             this->style.rail_padding,
+                             this->style.rail_padding);
+  layout->setSpacing(this->style.button_spacing);
+
+  this->search = new QLineEdit(this);
+  this->search->setPlaceholderText("Search nodes...");
+  this->search->setClearButtonEnabled(true);
+  layout->addWidget(this->search);
+
+  this->build_rail(inventory);
+  this->setup_search(inventory);
+
+  // the rail scrolls so every category stays reachable when the interface is
+  // scaled up or the window is short
+  auto *scroll = new QScrollArea(this);
+  scroll->setWidget(this->rail);
+  scroll->setWidgetResizable(true);
+  scroll->setFrameShape(QFrame::NoFrame);
+  scroll->setHorizontalScrollBarPolicy(Qt::ScrollBarAlwaysOff);
+  layout->addWidget(scroll, 1);
+
+  this->setToolTip("Click a category for its nodes.\n"
+                   "Ctrl + click a node: replace the selected node\n"
+                   "Shift + click a node: chain to the selected node");
+
+  this->set_style(this->style);
+}
+
+NodePaletteSidebar::~NodePaletteSidebar() { live_sidebars().erase(this); }
+
+QColor NodePaletteSidebar::accent_for(const QString &category) const
+{
+  const auto it = this->category_colors.find(category.toStdString());
+  if (it != this->category_colors.end() && it->second.isValid())
+  {
+    QColor color = it->second;
+    color.setAlpha(255);
+
+    // several registry colours are near-black, which is invisible as a glyph on
+    // a dark rail; lift only those rather than recolouring the whole palette
+    if (color.lightness() < 70)
+      color = blend(color, QColor("#c8c8c8"), 0.55);
+
+    return color;
+  }
+
+  return derived_accent(category);
+}
+
+std::vector<std::string> NodePaletteSidebar::all_node_types() const
+{
+  std::vector<std::string> all;
+  for (const auto &types : this->node_types)
+    all.insert(all.end(), types.begin(), types.end());
+
+  std::sort(all.begin(), all.end());
+  all.erase(std::unique(all.begin(), all.end()), all.end());
+  return all;
+}
+
+void NodePaletteSidebar::apply_menu_style(QMenu *menu, const QColor &accent)
+{
+  const QString sheet =
+      QString("QMenu {"
+              "  background-color: %1;"
+              "  color: %2;"
+              "  border: 1px solid %3;"
+              "  border-left: 2px solid %4;"
+              "  border-radius: %5px;"
+              "  padding: %6px;"
+              // Without this a category with more entries than the screen is
+              // tall gets laid out in multiple columns, which overshoots the
+              // screen by the frame and puts the last column off the edge. A
+              // scrolling single column is both correct and easier to read.
+              "  menu-scrollable: 1;"
+              "}"
+              "QMenu::item {"
+              "  background: transparent;"
+              "  height: %7px;"
+              "  padding-left: 14px;"
+              "  padding-right: 28px;"
+              "  border-radius: %8px;"
+              "}"
+              "QMenu::item:selected {"
+              "  background-color: %9;"
+              "  color: %10;"
+              "}"
+              "QMenu::item:disabled { color: %3; }"
+              "QMenu::separator {"
+              "  height: 1px;"
+              "  background: %3;"
+              "  margin: %6px 8px;"
+              "}"
+              "QMenu::icon { padding-left: 10px; }")
+          .arg(this->style.flyout_bg.name())
+          .arg(this->style.text.name())
+          .arg(this->style.flyout_border.name())
+          .arg(accent.name())
+          .arg(std::max(0, this->style.corner_radius))
+          .arg(std::max(0, this->style.flyout_padding))
+          .arg(std::max(12, this->style.flyout_row_height))
+          .arg(std::max(0, this->style.corner_radius / 2))
+          .arg(this->style.surface_selected.name())
+          .arg(this->style.text_active.name());
+
+  menu->setStyleSheet(sheet);
+
+  for (QAction *action : menu->actions())
+    if (action->menu())
+      this->apply_menu_style(action->menu(), accent);
+}
+
+void NodePaletteSidebar::build_rail(const std::map<std::string, std::string> &inventory)
+{
+  // node type -> "Cat/Sub/Sub" becomes a per-category tree; the rail is the top
+  // level, everything below it is a flyout
+  struct TreeNode
+  {
+    std::map<QString, TreeNode> children;
+    std::vector<QString>        leaves;
+  };
+
+  std::map<QString, TreeNode> roots;
+
+  for (const auto &[node_type, path] : inventory)
+  {
+    const QStringList parts = split_path(QString::fromStdString(path));
+    if (parts.isEmpty())
+      continue;
+
+    TreeNode *cursor = &roots[parts.front()];
+    for (int i = 1; i < parts.size(); ++i)
+      cursor = &cursor->children[parts.at(i)];
+
+    cursor->leaves.push_back(QString::fromStdString(node_type));
+  }
+
+  this->rail = new QWidget;
+  auto *rail_layout = new QVBoxLayout(this->rail);
+  rail_layout->setContentsMargins(0, 0, 0, 0);
+  rail_layout->setSpacing(this->style.button_spacing);
+
+  // recursive menu build, so a category three levels deep is not a special case
+  std::function<void(QMenu *, const TreeNode &, const QColor &)> fill =
+      [&](QMenu *menu, const TreeNode &node, const QColor &accent)
+  {
+    std::vector<QString> leaves = node.leaves;
+    std::sort(leaves.begin(), leaves.end());
+
+    for (const QString &leaf : leaves)
+    {
+      QAction *action = menu->addAction(leaf);
+      action->setData(leaf);
+
+      // connected per action rather than through QMenu::triggered: that signal
+      // only reaches the root menu along the popup chain, so a node picked from
+      // a submenu would depend on how the menu happened to be opened
+      this->connect(action,
+                    &QAction::triggered,
+                    this,
+                    [this, leaf]() { this->emit_for_type(leaf); });
+    }
+
+    if (!leaves.empty() && !node.children.empty())
+      menu->addSeparator();
+
+    for (const auto &[name, child] : node.children)
+    {
+      QMenu *sub = menu->addMenu(name.toUpper());
+      fill(sub, child, accent);
+    }
+  };
+
+  int max_width = 0;
+
+  for (const auto &[category, tree] : roots)
+  {
+    const QColor accent = this->accent_for(category);
+
+    auto *button = new CategoryRailButton(category, accent, this->style, this->rail);
+    rail_layout->addWidget(button);
+
+    auto *menu = new QMenu(category, this);
+    fill(menu, tree, accent);
+    this->apply_menu_style(menu, accent);
+
+    // filter the whole tree, not just the root: submenus need the show-time
+    // screen clamp, and mouse moves over them still have to switch categories
+    std::function<void(QMenu *)> watch = [&](QMenu *m)
+    {
+      m->installEventFilter(this);
+      for (QAction *action : m->actions())
+        if (action->menu())
+          watch(action->menu());
+    };
+    watch(menu);
+
+    // collect every leaf under this category, for the tests and for the search
+    std::vector<std::string> types;
+    std::function<void(const TreeNode &)> collect = [&](const TreeNode &node)
+    {
+      for (const QString &leaf : node.leaves)
+        types.push_back(leaf.toStdString());
+      for (const auto &[_, child] : node.children)
+        collect(child);
+    };
+    collect(tree);
+    std::sort(types.begin(), types.end());
+
+    const int index = static_cast<int>(this->buttons.size());
+
+    this->buttons.push_back(button);
+    this->menus.push_back(menu);
+    this->node_types.push_back(std::move(types));
+
+    this->connect(button,
+                  &QAbstractButton::clicked,
+                  this,
+                  [this, index]()
+                  {
+                    if (this->open_index == index)
+                      this->close_flyout();
+                    else
+                      this->open_category(index);
+                  });
+
+    this->connect(button,
+                  &CategoryRailButton::hovered,
+                  this,
+                  [this, index]()
+                  {
+                    // only follow the pointer once the palette is already open,
+                    // so a stray pass over the rail does not spawn a flyout
+                    if (this->open_index >= 0 && this->open_index != index)
+                      this->open_category(index);
+                  });
+
+    max_width = std::max(max_width, button->sizeHint().width());
+  }
+
+  rail_layout->addStretch(1);
+
+  this->setMinimumWidth(max_width + 4 * this->style.rail_padding);
+}
+
+CategoryRailButton *NodePaletteSidebar::button_at(int index) const
+{
+  if (index < 0 || index >= static_cast<int>(this->buttons.size()))
+    return nullptr;
+  return this->buttons.at(index);
+}
+
+int NodePaletteSidebar::category_count() const
+{
+  return static_cast<int>(this->buttons.size());
+}
+
+QStringList NodePaletteSidebar::category_names() const
+{
+  QStringList names;
+  for (CategoryRailButton *button : this->buttons)
+    names << button->text();
+  return names;
+}
+
+void NodePaletteSidebar::close_flyout()
+{
+  if (this->open_index < 0)
+    return;
+
+  const int index = this->open_index;
+  this->open_index = -1;
+
+  if (QMenu *menu = this->menu_at(index))
+    menu->close();
+
+  if (CategoryRailButton *button = this->button_at(index))
+    button->set_open(false);
+}
+
+void NodePaletteSidebar::emit_for_type(const QString &node_type)
+{
+  const std::string type = node_type.toStdString();
+  const auto        modifiers = QApplication::keyboardModifiers();
+
+  if (modifiers & Qt::ControlModifier)
+    Q_EMIT this->node_type_selected_ctrl(type);
+  else if (modifiers & Qt::ShiftModifier)
+    Q_EMIT this->node_type_selected_shift(type);
+  else
+    Q_EMIT this->node_type_selected(type);
+}
+
+bool NodePaletteSidebar::eventFilter(QObject *watched, QEvent *event)
+{
+  // Submenus are popped up by Qt, not by us, so this is the only place a deep
+  // node list can be pulled back onto the screen. Move and Resize are watched
+  // as well as Show because Qt keeps adjusting a scrollable menu after it has
+  // been shown, and the last word has to be the screen's.
+  if (event->type() == QEvent::Show || event->type() == QEvent::Move ||
+      event->type() == QEvent::Resize)
+  {
+    if (auto *menu = qobject_cast<QMenu *>(watched))
+      if (menu->isVisible())
+        if (const QScreen *screen = menu->screen())
+          clamp_to_screen(menu, screen->availableGeometry());
+  }
+
+  if (event->type() == QEvent::MouseMove && this->open_index >= 0)
+  {
+    auto *move = static_cast<QMouseEvent *>(event);
+    const QPoint global = move->globalPosition().toPoint();
+
+    for (int i = 0; i < static_cast<int>(this->buttons.size()); ++i)
+    {
+      CategoryRailButton *button = this->buttons.at(i);
+      if (i == this->open_index || !button->isVisible())
+        continue;
+
+      if (button->rect().contains(button->mapFromGlobal(global)))
+      {
+        // reopening from inside the menu's own event delivery re-enters
+        // QMenu::popup; defer it by one turn of the loop
+        QTimer::singleShot(0, this, [this, i]() { this->open_category(i); });
+        break;
+      }
+    }
+  }
+
+  return QWidget::eventFilter(watched, event);
+}
+
+const NodePaletteStyle &NodePaletteSidebar::get_style() const { return this->style; }
+
+QMenu *NodePaletteSidebar::menu_at(int index) const
+{
+  if (index < 0 || index >= static_cast<int>(this->menus.size()))
+    return nullptr;
+  return this->menus.at(index);
+}
+
+std::vector<std::string> NodePaletteSidebar::node_types_at(int index) const
+{
+  if (index < 0 || index >= static_cast<int>(this->node_types.size()))
+    return {};
+  return this->node_types.at(index);
+}
+
+void NodePaletteSidebar::open_category(int index)
+{
+  CategoryRailButton *button = this->button_at(index);
+  QMenu              *menu = this->menu_at(index);
+
+  if (!button || !menu)
+    return;
+
+  if (this->open_index >= 0 && this->open_index != index)
+    this->close_flyout();
+
+  this->open_index = index;
+  button->set_open(true);
+
+  // flush against the button's right edge: a gap here is the classic hover dead
+  // zone, where the pointer leaves the button before it reaches the flyout
+  QPoint pos = button->mapToGlobal(QPoint(button->width(), 0));
+
+  const QScreen *screen = button->screen();
+  QRect          available;
+
+  if (screen)
+  {
+    available = screen->availableGeometry();
+
+    // nudge upwards up front, so the common case does not flip the whole menu
+    // over the rail
+    const int height = menu->sizeHint().height();
+    if (pos.y() + height > available.bottom())
+      pos.setY(std::max(available.top(), available.bottom() - height));
+  }
+
+  menu->popup(pos);
+
+  if (!available.isNull())
+    clamp_to_screen(menu, available);
+}
+
+int NodePaletteSidebar::open_category_index() const { return this->open_index; }
+
+void NodePaletteSidebar::restyle_all(const NodePaletteStyle &style)
+{
+  for (NodePaletteSidebar *sidebar : live_sidebars())
+    sidebar->set_style(style);
+}
+
+QLineEdit *NodePaletteSidebar::search_field() const { return this->search; }
+
+void NodePaletteSidebar::set_style(const NodePaletteStyle &new_style)
+{
+  this->style = new_style;
+
+  if (auto *layout = qobject_cast<QVBoxLayout *>(this->layout()))
+  {
+    layout->setContentsMargins(this->style.rail_padding,
+                               this->style.rail_padding,
+                               this->style.rail_padding,
+                               this->style.rail_padding);
+    layout->setSpacing(this->style.button_spacing);
+  }
+
+  if (this->rail && this->rail->layout())
+    this->rail->layout()->setSpacing(this->style.button_spacing);
+
+  int max_width = 0;
+
+  for (int i = 0; i < static_cast<int>(this->buttons.size()); ++i)
+  {
+    CategoryRailButton *button = this->buttons.at(i);
+    button->set_style(this->style);
+    max_width = std::max(max_width, button->sizeHint().width());
+
+    if (QMenu *menu = this->menu_at(i))
+      this->apply_menu_style(menu, this->accent_for(button->text()));
+  }
+
+  if (this->search)
+    this->search->setStyleSheet(
+        QString("QLineEdit { background-color: %1; color: %2; border: 1px solid %3;"
+                " border-radius: %4px; padding: 4px 8px; }")
+            .arg(this->style.flyout_bg.name())
+            .arg(this->style.text_active.name())
+            .arg(this->style.flyout_border.name())
+            .arg(std::max(0, this->style.corner_radius)));
+
+  if (max_width > 0)
+    this->setMinimumWidth(max_width + 4 * this->style.rail_padding);
+
+  this->update();
+}
+
+void NodePaletteSidebar::setup_search(
+    const std::map<std::string, std::string> &inventory)
+{
+  QStringList entries;
+
+  for (const auto &[node_type, path] : inventory)
+  {
+    // the category is part of the searchable string so "erosion" finds the
+    // whole family, not just the nodes with it in their name
+    const QString display = QString("%1  ·  %2")
+                                .arg(QString::fromStdString(node_type))
+                                .arg(QString::fromStdString(path));
+
+    entries << display;
+    this->search_index[display] = QString::fromStdString(node_type);
+  }
+
+  auto *completer = new QCompleter(entries, this);
+  completer->setCaseSensitivity(Qt::CaseInsensitive);
+  completer->setFilterMode(Qt::MatchContains);
+  completer->setCompletionMode(QCompleter::PopupCompletion);
+  completer->setMaxVisibleItems(14);
+
+  this->search->setCompleter(completer);
+
+  // QCompleter's popup brings arrow keys, Enter, Escape, scrolling and
+  // screen-bounds handling with it, so none of that is reimplemented here
+  this->connect(completer,
+                QOverload<const QString &>::of(&QCompleter::activated),
+                this,
+                [this](const QString &display)
+                {
+                  const auto it = this->search_index.find(display);
+                  if (it == this->search_index.end())
+                    return;
+
+                  const QString type = it->second;
+                  this->search->clear();
+                  this->emit_for_type(type);
+                });
+
+  // Enter without picking from the popup still works when the text names a node
+  this->connect(this->search,
+                &QLineEdit::returnPressed,
+                this,
+                [this]()
+                {
+                  const QString text = this->search->text().trimmed();
+                  if (text.isEmpty())
+                    return;
+
+                  for (const auto &[display, type] : this->search_index)
+                    if (type.compare(text, Qt::CaseInsensitive) == 0)
+                    {
+                      this->search->clear();
+                      this->emit_for_type(type);
+                      return;
+                    }
+                });
+}
+
+} // namespace hesiod

--- a/Hesiod/src/gui/widgets/node_palette_sidebar.cpp
+++ b/Hesiod/src/gui/widgets/node_palette_sidebar.cpp
@@ -177,37 +177,47 @@ void draw_glyph(QPainter &painter, const QRectF &box, const QColor &color, int s
  * QMenu positions itself on the screen, but a menu with more entries than the
  * display is tall is laid out in columns first, and that layout overshoots by
  * the frame width -- measured at every scale from 0.5x to 3x, the last column
- * ended up 13 to 88 logical pixels below the bottom of the screen. With
- * `menu-scrollable` on, shrinking it here turns the overflow into scroll arrows
- * instead of clipped entries.
+ * ended up 13 to 88 logical pixels below the bottom of the screen. Sliding the
+ * popup back inside fixes that; its size is left to QMenu, whose own scroll
+ * arrows (`menu-scrollable`) handle a list taller than the display.
  */
 void clamp_to_screen(QMenu *menu, const QRect &available)
 {
-  // setGeometry() below produces move/resize events that come straight back
-  // here; one pass is always enough, so refuse to re-enter rather than relying
-  // on the rectangle happening to be a fixed point
+  // move() below produces a move event that comes straight back here; one pass
+  // is always enough, so refuse to re-enter rather than relying on the
+  // rectangle happening to be a fixed point
   static bool clamping = false;
   if (clamping)
     return;
 
-  QRect geom = menu->geometry();
+  const QRect geom = menu->geometry();
+  QRect       moved = geom;
 
-  geom.setSize(geom.size().boundedTo(available.size()));
+  // Move only, never resize. A popup's size is decided by QMenu's own layout
+  // pass (column count, scroll arrows, the native shadow margin around it);
+  // forcing a different size from the outside leaves the widget's idea of its
+  // rectangle and the platform window disagreeing, and every mouse position is
+  // then translated through the wrong one -- the cursor highlights one entry
+  // while the click lands on another. Anything genuinely taller than the screen
+  // is handled by the menu's own scroll arrows, which is what `menu-scrollable`
+  // in the stylesheet is for.
+  if (moved.bottom() > available.bottom())
+    moved.moveBottom(available.bottom());
+  if (moved.right() > available.right())
+    moved.moveRight(available.right());
 
-  if (geom.bottom() > available.bottom())
-    geom.moveBottom(available.bottom());
-  if (geom.top() < available.top())
-    geom.moveTop(available.top());
-  if (geom.right() > available.right())
-    geom.moveRight(available.right());
-  if (geom.left() < available.left())
-    geom.moveLeft(available.left());
+  // top/left last: on a menu taller or wider than the screen these win, so the
+  // start of the list stays reachable rather than its end
+  if (moved.top() < available.top())
+    moved.moveTop(available.top());
+  if (moved.left() < available.left())
+    moved.moveLeft(available.left());
 
-  if (geom == menu->geometry())
+  if (moved.topLeft() == geom.topLeft())
     return;
 
   clamping = true;
-  menu->setGeometry(geom);
+  menu->move(moved.topLeft());
   clamping = false;
 }
 

--- a/Hesiod/src/gui/widgets/scrollable_dialog.cpp
+++ b/Hesiod/src/gui/widgets/scrollable_dialog.cpp
@@ -1,0 +1,150 @@
+/* Copyright (c) 2026 Otto Link. Distributed under the terms of the GNU General
+ * Public License. The full license is in the file LICENSE, distributed with
+ * this software. */
+#include <algorithm>
+
+#include <QGuiApplication>
+#include <QPushButton>
+#include <QScreen>
+#include <QScrollBar>
+#include <QShowEvent>
+#include <QVBoxLayout>
+
+#include "hesiod/gui/widgets/scrollable_dialog.hpp"
+
+namespace hesiod
+{
+
+namespace
+{
+/// Breathing room left between the dialog and the screen edges, logical px.
+constexpr int kScreenMargin = 48;
+
+/// Smallest the dialog may be clamped to; below this it is unusable anyway.
+constexpr int kMinWidth = 320;
+constexpr int kMinHeight = 220;
+} // namespace
+
+ScrollableDialog::ScrollableDialog(QWidget                          *content,
+                                   const QString                    &title,
+                                   QDialogButtonBox::StandardButtons button_set,
+                                   QWidget                          *parent)
+    : QDialog(parent), body(content)
+{
+  this->setWindowTitle(title);
+
+  this->scroll = new QScrollArea(this);
+  this->scroll->setWidgetResizable(true);
+  this->scroll->setFrameShape(QFrame::NoFrame);
+
+  // both on demand: a pane too wide for the screen has to stay pannable, and
+  // clipping it is what makes a control unreachable at a large interface scale
+  this->scroll->setHorizontalScrollBarPolicy(Qt::ScrollBarAsNeeded);
+  this->scroll->setVerticalScrollBarPolicy(Qt::ScrollBarAsNeeded);
+
+  if (this->body)
+  {
+    this->body->setParent(nullptr); // the scroll area reparents it
+    this->scroll->setWidget(this->body);
+  }
+
+  // The scroll area's own size hint follows its widget, which would drag the
+  // dialog back up to the content's full height. A small minimum is what lets
+  // the user shrink the dialog and lets fit_to() clamp it.
+  this->scroll->setMinimumSize(kMinWidth, kMinHeight);
+
+  this->buttons = new QDialogButtonBox(button_set, this);
+  if (QPushButton *ok = this->buttons->button(QDialogButtonBox::Ok))
+    ok->setDefault(true);
+
+  this->connect(this->buttons, &QDialogButtonBox::accepted, this, &QDialog::accept);
+  this->connect(this->buttons, &QDialogButtonBox::rejected, this, &QDialog::reject);
+
+  auto *layout = new QVBoxLayout(this);
+  layout->addWidget(this->scroll, 1);
+  layout->addWidget(this->buttons, 0); // outside the scroll area, always visible
+
+  this->setSizeGripEnabled(true);
+}
+
+QRect ScrollableDialog::available_screen_rect() const
+{
+  const QScreen *screen = this->screen();
+
+  if (!screen && this->parentWidget())
+    screen = this->parentWidget()->screen();
+
+  if (!screen)
+    screen = QGuiApplication::primaryScreen();
+
+  return screen ? screen->availableGeometry() : QRect(0, 0, 1024, 768);
+}
+
+QDialogButtonBox *ScrollableDialog::button_box() const { return this->buttons; }
+
+QWidget *ScrollableDialog::content() const { return this->body; }
+
+void ScrollableDialog::fit_to(const QRect &available)
+{
+  const int max_w = std::max(kMinWidth, available.width() - kScreenMargin);
+  const int max_h = std::max(kMinHeight, available.height() - kScreenMargin);
+
+  // what the dialog would like: the content's own width plus the frame, and
+  // enough height for content and buttons
+  int wanted_w = kMinWidth;
+  int wanted_h = kMinHeight;
+
+  if (this->body)
+  {
+    const QSize hint = this->body->sizeHint().expandedTo(
+        this->body->minimumSizeHint());
+
+    // room for the vertical scrollbar, so the content is not squeezed sideways
+    // the moment it becomes tall enough to need one
+    const int bar = this->scroll->verticalScrollBar()
+                        ? this->scroll->verticalScrollBar()->sizeHint().width()
+                        : 16;
+
+    wanted_w = hint.width() + bar;
+    wanted_h = hint.height();
+  }
+
+  wanted_h += this->buttons ? this->buttons->sizeHint().height() : 0;
+
+  if (QLayout *l = this->layout())
+  {
+    const QMargins m = l->contentsMargins();
+    wanted_w += m.left() + m.right();
+    wanted_h += m.top() + m.bottom() + l->spacing();
+  }
+
+  const QSize size(std::clamp(wanted_w, kMinWidth, max_w),
+                   std::clamp(wanted_h, kMinHeight, max_h));
+
+  // never let a minimum size hold the dialog larger than the screen: that is
+  // exactly the state where the buttons end up unreachable
+  this->setMaximumSize(max_w, max_h);
+  this->resize(size);
+
+  QRect geom = this->geometry();
+  geom.setSize(size);
+  geom.moveCenter(available.center());
+  this->setGeometry(geom);
+}
+
+QScrollArea *ScrollableDialog::scroll_area() const { return this->scroll; }
+
+void ScrollableDialog::showEvent(QShowEvent *event)
+{
+  // fit once, on first show: doing it on every show would undo a size the user
+  // dragged to
+  if (!this->fitted)
+  {
+    this->fitted = true;
+    this->fit_to(this->available_screen_rect());
+  }
+
+  QDialog::showEvent(event);
+}
+
+} // namespace hesiod

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,0 +1,1 @@
+add_subdirectory(ui_palette)

--- a/tests/ui_palette/CMakeLists.txt
+++ b/tests/ui_palette/CMakeLists.txt
@@ -1,0 +1,31 @@
+# Regression tests for the interface scale and the node palette sidebar.
+#
+# Deliberately built from the handful of sources under test rather than by
+# linking the application: both live behind plain value types (no HesiodApplication,
+# no OpenCL, no node registry), so the test binary compiles in seconds and the
+# tests cannot accidentally depend on a running application context.
+
+set(TARGET hesiod_ui_palette_test)
+
+set(HESIOD_SRC ${CMAKE_CURRENT_SOURCE_DIR}/../../Hesiod)
+
+add_executable(
+  ${TARGET}
+  main.cpp
+  ${HESIOD_SRC}/src/app/ui_scale.cpp
+  ${HESIOD_SRC}/src/gui/widgets/node_palette_sidebar.cpp
+  ${HESIOD_SRC}/src/gui/widgets/scrollable_dialog.cpp
+  ${HESIOD_SRC}/src/logger.cpp
+  ${HESIOD_SRC}/include/hesiod/gui/widgets/node_palette_sidebar.hpp
+  ${HESIOD_SRC}/include/hesiod/gui/widgets/scrollable_dialog.hpp)
+
+set_target_properties(${TARGET} PROPERTIES AUTOMOC ON)
+
+target_include_directories(${TARGET} PRIVATE ${HESIOD_SRC}/include)
+
+find_package(Qt6 REQUIRED COMPONENTS Test)
+
+target_link_libraries(${TARGET} PRIVATE Qt6::Core Qt6::Widgets Qt6::Test
+                                        spdlog::spdlog nlohmann_json::nlohmann_json)
+
+target_compile_features(${TARGET} PRIVATE cxx_std_20)

--- a/tests/ui_palette/main.cpp
+++ b/tests/ui_palette/main.cpp
@@ -315,6 +315,28 @@ void test_scale_environment_override()
           "and is not rewritten into our range");
   }
 
+  // A fractional factor has to survive the round trip through the environment
+  // exactly. 'g' formatting can emit an exponent, and a non-C locale can emit a
+  // comma, both of which Qt reparses as something else entirely -- 0.9 arriving
+  // as 0 or 9 is the difference between a slightly smaller interface and an
+  // unusable one.
+  qunsetenv("QT_SCALE_FACTOR");
+  for (const double factor : {0.5, 0.75, 0.9, 1.05, 1.25, 2.5, 3.0})
+  {
+    ui_scale::apply_scale(factor);
+
+    const QByteArray written = qgetenv("QT_SCALE_FACTOR");
+
+    check(std::abs(written.toDouble() - factor) < 1e-9,
+          "a fractional scale reaches Qt unchanged");
+    check(!written.contains('e') && !written.contains('E'),
+          "the factor is never written in exponent form");
+    check(!written.contains(','),
+          "the factor never carries a locale decimal comma");
+
+    qunsetenv("QT_SCALE_FACTOR");
+  }
+
   if (had_original)
     qputenv("QT_SCALE_FACTOR", original);
   else

--- a/tests/ui_palette/main.cpp
+++ b/tests/ui_palette/main.cpp
@@ -1,0 +1,948 @@
+/* Copyright (c) 2026 Otto Link. Distributed under the terms of the GNU General
+ * Public License. The full license is in the file LICENSE, distributed with
+ * this software. */
+#include <algorithm>
+#include <cmath>
+#include <fstream>
+#include <iostream>
+#include <limits>
+#include <set>
+
+#include <QAbstractItemView>
+#include <QApplication>
+#include <QCompleter>
+#include <QDir>
+#include <QEnterEvent>
+#include <QPainter>
+#include <QScreen>
+#include <QScrollArea>
+#include <QScrollBar>
+#include <QSignalSpy>
+#include <QTemporaryDir>
+#include <QTest>
+
+#include <QCheckBox>
+#include <QFileInfo>
+#include <QFormLayout>
+#include <QHBoxLayout>
+#include <QLabel>
+#include <QPushButton>
+
+#include "hesiod/app/ui_scale.hpp"
+#include "hesiod/gui/widgets/node_palette_sidebar.hpp"
+#include "hesiod/gui/widgets/scrollable_dialog.hpp"
+
+using namespace hesiod;
+
+// --- tiny harness, same shape as the gnodegui node_style test
+
+namespace
+{
+int g_failures = 0;
+
+void check(bool condition, const std::string &what)
+{
+  if (condition)
+  {
+    std::cout << "  ok   " << what << "\n";
+  }
+  else
+  {
+    std::cout << "  FAIL " << what << "\n";
+    ++g_failures;
+  }
+}
+
+void section(const std::string &name) { std::cout << "\n[" << name << "]\n"; }
+
+/// A stand-in inventory shaped exactly like get_node_inventory(): node type ->
+/// slash-separated category path, with a deep path, a category-root node and a
+/// category that the colour map does not name.
+std::map<std::string, std::string> sample_inventory()
+{
+  return {
+      {"Abs", "Math/Base"},
+      {"AbsSmooth", "Math/Base"},
+      {"Blend", "Operator/Blend"},
+      {"Blend3", "Operator/Blend"},
+      {"BlenderBridge", "Bridges"}, // node sitting directly on a category
+      {"Bulkify", "Boundaries"},    // category with no entry in the colour map
+      {"Clamp", "Filter/Range"},
+      {"Remap", "Filter/Range"},
+      {"FillTalus", "Filter/Advanced Filters"},
+      {"Thermal", "Erosion/Deposition"},
+      {"ValleyFill", "Erosion/Deposition"},
+      {"HydraulicParticle", "Erosion/Hydraulic"},
+      {"Strata", "Erosion/Stratify"},
+      {"AreaRemove", "Terrain Features/Morphology"},
+      {"CombineMask", "Terrain Features/Mask Operations"},
+      {"ExportHeightmap", "Export"},
+      {"Preview", "Debug"},
+      {"Noise", "Primitive/Coherent"},
+      {"CellularNoise", "Primitive/Coherent"},
+      {"Band", "Primitive/Function"},
+      {"Brush", "Primitive/Authoring"},
+  };
+}
+
+std::map<std::string, QColor> sample_colors()
+{
+  return {{"Math", QColor(0, 43, 54)}, // near black in the real registry
+          {"Operator", QColor(108, 113, 196)},
+          {"Filter", QColor(108, 113, 196)},
+          {"Erosion", QColor(203, 75, 22)},
+          {"Debug", QColor(200, 0, 0)},
+          {"Primitive", QColor(42, 161, 152)}};
+}
+
+QAction *find_action(QMenu *menu, const QString &text)
+{
+  for (QAction *action : menu->actions())
+  {
+    if (action->menu())
+    {
+      if (QAction *hit = find_action(action->menu(), text))
+        return hit;
+    }
+    else if (action->text() == text)
+    {
+      return action;
+    }
+  }
+  return nullptr;
+}
+
+int count_leaf_actions(QMenu *menu)
+{
+  int n = 0;
+  for (QAction *action : menu->actions())
+  {
+    if (action->menu())
+      n += count_leaf_actions(action->menu());
+    else if (!action->isSeparator())
+      ++n;
+  }
+  return n;
+}
+
+void write_config(const QString &path, const std::string &body)
+{
+  std::ofstream file(path.toStdString());
+  file << body;
+}
+
+} // namespace
+
+// =====================================
+// interface scale
+// =====================================
+
+void test_scale_sanitizing()
+{
+  section("interface scale: validation");
+
+  bool clean = false;
+
+  check(ui_scale::sanitize(1.25, &clean) == 1.25 && clean, "an in-range factor is kept");
+
+  check(ui_scale::sanitize(std::numeric_limits<double>::quiet_NaN()) ==
+            ui_scale::kDefault,
+        "NaN falls back to 1.00");
+  check(ui_scale::sanitize(std::numeric_limits<double>::infinity()) ==
+            ui_scale::kDefault,
+        "infinity falls back to 1.00");
+  check(ui_scale::sanitize(-std::numeric_limits<double>::infinity()) ==
+            ui_scale::kDefault,
+        "negative infinity falls back to 1.00");
+
+  check(ui_scale::sanitize(9.0, &clean) == ui_scale::kMax && !clean,
+        "a too-large factor clamps to the maximum and is reported as corrected");
+  check(ui_scale::sanitize(0.01, &clean) == ui_scale::kMin && !clean,
+        "a too-small factor clamps to the minimum");
+  check(ui_scale::sanitize(-4.0) == ui_scale::kMin, "a negative factor clamps up");
+  check(ui_scale::sanitize(0.0) == ui_scale::kMin, "zero clamps up");
+
+  // the property that makes repeated changes safe: sanitize is idempotent, so
+  // storing and re-reading a value can never walk it anywhere
+  for (const double value : {0.5, 0.83, 1.0, 1.25, 2.4, 3.0})
+    check(ui_scale::sanitize(ui_scale::sanitize(value)) == ui_scale::sanitize(value),
+          "sanitize is idempotent for " + std::to_string(value));
+}
+
+void test_scale_never_compounds()
+{
+  section("interface scale: repeated changes and reset");
+
+  QTemporaryDir dir;
+  const QString config = dir.filePath("hesiod.json");
+
+  // a settings round trip is: sanitize on write, sanitize on read. Doing it
+  // repeatedly must land exactly where a single jump would.
+  double running = ui_scale::kDefault;
+
+  for (const double requested : {1.25, 1.5, 0.75, 2.0, 2.0, 1.0})
+  {
+    write_config(config,
+                 "{\"app_settings\": {\"interface.ui_scale\": " +
+                     std::to_string(ui_scale::sanitize(requested)) + "}}");
+    running = ui_scale::scale_from_config(config.toStdString());
+
+    check(std::abs(running - requested) < 1e-9,
+          "setting " + std::to_string(requested) + " reads back unchanged");
+  }
+
+  check(std::abs(running - ui_scale::kDefault) < 1e-9,
+        "reset to 1.00 after five changes lands exactly on 1.00");
+
+  // the same sequence applied in one step gives the same answer
+  write_config(config, "{\"app_settings\": {\"interface.ui_scale\": 2.0}}");
+  const double direct = ui_scale::scale_from_config(config.toStdString());
+  write_config(config, "{\"app_settings\": {\"interface.ui_scale\": 2.0}}");
+  const double after_history = ui_scale::scale_from_config(config.toStdString());
+  check(direct == after_history, "the factor does not depend on the previous value");
+}
+
+void test_scale_malformed_config()
+{
+  section("interface scale: malformed persisted values");
+
+  QTemporaryDir dir;
+  const QString config = dir.filePath("hesiod.json");
+
+  check(ui_scale::scale_from_config(dir.filePath("nope.json").toStdString()) ==
+            ui_scale::kDefault,
+        "a missing config gives 1.00");
+
+  check(ui_scale::scale_from_config("") == ui_scale::kDefault,
+        "an empty path gives 1.00");
+
+  write_config(config, "{ this is not json");
+  check(ui_scale::scale_from_config(config.toStdString()) == ui_scale::kDefault,
+        "a truncated config gives 1.00 instead of throwing");
+
+  write_config(config, "{}");
+  check(ui_scale::scale_from_config(config.toStdString()) == ui_scale::kDefault,
+        "a config without app_settings gives 1.00");
+
+  write_config(config, "{\"app_settings\": {}}");
+  check(ui_scale::scale_from_config(config.toStdString()) == ui_scale::kDefault,
+        "a config without the key gives 1.00");
+
+  write_config(config, "{\"app_settings\": {\"interface.ui_scale\": \"huge\"}}");
+  check(ui_scale::scale_from_config(config.toStdString()) == ui_scale::kDefault,
+        "a string factor gives 1.00");
+
+  write_config(config, "{\"app_settings\": {\"interface.ui_scale\": null}}");
+  check(ui_scale::scale_from_config(config.toStdString()) == ui_scale::kDefault,
+        "a null factor gives 1.00");
+
+  write_config(config, "{\"app_settings\": {\"interface.ui_scale\": {\"x\": 2}}}");
+  check(ui_scale::scale_from_config(config.toStdString()) == ui_scale::kDefault,
+        "an object factor gives 1.00");
+
+  write_config(config, "{\"app_settings\": {\"interface.ui_scale\": 1e9}}");
+  check(ui_scale::scale_from_config(config.toStdString()) == ui_scale::kMax,
+        "an absurd factor clamps to the maximum rather than making the app unusable");
+
+  write_config(config, "{\"app_settings\": {\"interface.ui_scale\": -2}}");
+  check(ui_scale::scale_from_config(config.toStdString()) == ui_scale::kMin,
+        "a negative factor clamps to the minimum");
+
+  write_config(config, "{\"app_settings\": {\"interface.ui_scale\": 1.4}}");
+  check(std::abs(ui_scale::scale_from_config(config.toStdString()) - 1.4) < 1e-9,
+        "a good factor still reads back");
+}
+
+void test_scale_environment_override()
+{
+  section("interface scale: environment override");
+
+  const QByteArray original = qgetenv("QT_SCALE_FACTOR");
+  const bool       had_original = qEnvironmentVariableIsSet("QT_SCALE_FACTOR");
+
+  qunsetenv("QT_SCALE_FACTOR");
+  {
+    const ui_scale::Resolution r = ui_scale::apply_scale(1.5);
+    check(!r.environment_override, "with nothing in the environment there is no override");
+    check(r.configured == 1.5 && r.effective == 1.5,
+          "the preference is both configured and effective");
+    check(qgetenv("QT_SCALE_FACTOR").toDouble() == 1.5,
+          "QT_SCALE_FACTOR is set from the preference");
+    check(ui_scale::session_scale() == 1.5, "session_scale reports the applied factor");
+  }
+
+  // the misleading case: an override is in force, so the preference is *not*
+  // what the process runs at and must not be reported as if it were
+  qputenv("QT_SCALE_FACTOR", "2.5");
+  {
+    const ui_scale::Resolution r = ui_scale::apply_scale(1.25);
+    check(r.environment_override, "an existing QT_SCALE_FACTOR is flagged as an override");
+    check(qgetenv("QT_SCALE_FACTOR") == QByteArray("2.5"),
+          "the external value is preserved, not overwritten");
+    check(r.configured == 1.25, "the preference is still reported separately");
+    check(r.effective == 2.5, "the effective factor is the environment's");
+    check(ui_scale::session_scale() == 2.5,
+          "session_scale no longer claims the preference is active");
+    check(ui_scale::session_resolution().environment_override,
+          "the override is visible to the settings dialog");
+  }
+
+  // Qt ignores a factor it cannot use, so the process really does run at 1.00
+  qputenv("QT_SCALE_FACTOR", "not-a-number");
+  {
+    const ui_scale::Resolution r = ui_scale::apply_scale(2.0);
+    check(r.environment_override, "an unparseable override is still an override");
+    check(r.effective == ui_scale::kDefault,
+          "an unparseable override means the process runs at 1.00");
+    check(qgetenv("QT_SCALE_FACTOR") == QByteArray("not-a-number"),
+          "an unparseable override is still left alone");
+  }
+
+  qputenv("QT_SCALE_FACTOR", "0");
+  check(ui_scale::apply_scale(2.0).effective == ui_scale::kDefault,
+        "a zero override means 1.00");
+
+  qputenv("QT_SCALE_FACTOR", "-1");
+  check(ui_scale::apply_scale(2.0).effective == ui_scale::kDefault,
+        "a negative override means 1.00");
+
+  qputenv("QT_SCALE_FACTOR", "5");
+  {
+    const ui_scale::Resolution r = ui_scale::apply_scale(1.0);
+    check(r.effective == 5.0,
+          "an override beyond our supported range is reported as-is, not clamped");
+    check(qgetenv("QT_SCALE_FACTOR") == QByteArray("5"),
+          "and is not rewritten into our range");
+  }
+
+  if (had_original)
+    qputenv("QT_SCALE_FACTOR", original);
+  else
+    qunsetenv("QT_SCALE_FACTOR");
+
+  ui_scale::apply_scale(ui_scale::kDefault);
+}
+
+void test_executable_path()
+{
+  section("interface scale: executable path");
+
+  const QString dir = QString::fromStdString(ui_scale::executable_dir(nullptr));
+
+  check(!dir.isEmpty(), "the executable directory resolves without argv[0]");
+  check(QDir(dir).exists(), "it names a directory that exists");
+  check(QDir(dir).canonicalPath() ==
+            QDir(QFileInfo(QCoreApplication::applicationFilePath()).absolutePath())
+                .canonicalPath(),
+        "it matches what Qt reports once the application exists");
+
+  // a launch through PATH hands us a bare name; resolving that against the
+  // working directory would look for the portable config in the wrong place
+  check(QString::fromStdString(ui_scale::executable_dir("hesiod.exe")) == dir,
+        "a bare argv[0] does not move the resolved directory");
+  check(QString::fromStdString(ui_scale::executable_dir("../../hesiod.exe")) == dir,
+        "a relative argv[0] does not move it either");
+
+  check(QString::fromStdString(ui_scale::startup_config_path(nullptr))
+            .endsWith("hesiod.json"),
+        "the resolved config path names hesiod.json");
+}
+
+// =====================================
+// settings dialog
+// =====================================
+
+QWidget *make_settings_stub(int rows)
+{
+  auto *widget = new QWidget;
+  auto *form = new QFormLayout(widget);
+  form->setRowWrapPolicy(QFormLayout::WrapLongRows);
+
+  for (int i = 0; i < rows; ++i)
+    form->addRow(QString("A settings label of realistic length, number %1").arg(i),
+                 new QCheckBox);
+
+  return widget;
+}
+
+void test_settings_dialog()
+{
+  section("settings dialog: scrolling and screen cap");
+
+  QWidget  *content = make_settings_stub(80);
+  const int content_height = content->sizeHint().height();
+
+  ScrollableDialog dialog(content, "Application Settings");
+
+  check(dialog.scroll_area() != nullptr, "the content is inside a scroll area");
+  check(dialog.scroll_area()->widgetResizable(),
+        "the scroll area resizes its widget to the viewport, so rows reflow");
+  check(dialog.scroll_area()->widget() == content,
+        "the settings pane is the scrolled widget");
+  check(dialog.button_box() != nullptr, "the dialog has a button box");
+  check(!dialog.scroll_area()->isAncestorOf(dialog.button_box()),
+        "OK sits outside the scroll area, so it cannot scroll out of reach");
+  check(dialog.button_box()->button(QDialogButtonBox::Ok) != nullptr,
+        "the OK button exists");
+
+  // a screen far smaller than the content: this is the 200%-on-a-laptop case
+  const QRect tiny(0, 0, 600, 400);
+
+  dialog.show();
+  dialog.fit_to(tiny);
+  QApplication::processEvents();
+
+  check(content_height > tiny.height(),
+        "the stub content really is taller than the test screen");
+  check(dialog.height() <= tiny.height(), "the dialog is not taller than the screen");
+  check(dialog.width() <= tiny.width(), "the dialog is not wider than the screen");
+  check(tiny.contains(dialog.geometry()),
+        "the whole dialog sits inside the screen rectangle");
+
+  QScrollBar *vbar = dialog.scroll_area()->verticalScrollBar();
+  check(vbar->maximum() > 0, "the content scrolls rather than being clipped");
+  vbar->setValue(vbar->maximum());
+  QApplication::processEvents();
+  check(vbar->value() == vbar->maximum(), "the last row can be scrolled to");
+
+  check(dialog.button_box()->isVisible(), "OK is visible");
+  check(dialog.rect().contains(dialog.button_box()->geometry()),
+        "OK stays inside the dialog no matter how far the content is scrolled");
+
+  dialog.hide();
+
+  // horizontal overflow must be pannable, not a reason for a control to be
+  // unreachable
+  auto *wide = new QWidget;
+  auto *wide_layout = new QHBoxLayout(wide);
+  wide_layout->addWidget(new QLabel(QString(400, QChar('W'))));
+
+  ScrollableDialog wide_dialog(wide, "Wide content");
+  wide_dialog.show();
+  wide_dialog.fit_to(tiny);
+  QApplication::processEvents();
+
+  check(wide_dialog.width() <= tiny.width(),
+        "a pane wider than the screen does not widen the dialog past it");
+  check(wide_dialog.scroll_area()->horizontalScrollBar()->maximum() > 0,
+        "a pane wider than the screen can be scrolled sideways");
+  check(wide_dialog.button_box()->isVisible(),
+        "OK is still reachable with horizontal overflow");
+
+  wide_dialog.hide();
+
+  // and against the screen this process actually has, at whatever scale it is
+  // running: the same clamp has to hold there, which is the case that broke
+  ScrollableDialog real_dialog(make_settings_stub(80), "Application Settings");
+  real_dialog.show();
+  QApplication::processEvents();
+
+  const QRect available = real_dialog.available_screen_rect();
+  check(real_dialog.height() <= available.height(),
+        "on this process's real screen the dialog is not taller than it");
+  check(real_dialog.width() <= available.width(),
+        "and not wider than it");
+  check(real_dialog.button_box()->isVisible(),
+        "OK is on screen at this process's interface scale");
+
+  real_dialog.hide();
+}
+
+// =====================================
+// node palette sidebar
+// =====================================
+
+void test_category_completeness()
+{
+  section("sidebar: categories and node coverage");
+
+  const auto inventory = sample_inventory();
+
+  NodePaletteSidebar sidebar(inventory, sample_colors(), NodePaletteStyle{});
+
+  // the rail is exactly the set of distinct top-level categories
+  std::set<QString> expected;
+  for (const auto &[type, path] : inventory)
+    expected.insert(QString::fromStdString(path).split('/').front());
+
+  const QStringList names = sidebar.category_names();
+  check(names.size() == static_cast<int>(expected.size()),
+        "one rail button per top-level category");
+
+  bool all_named = true;
+  for (const QString &name : names)
+    all_named &= expected.count(name) > 0;
+  check(all_named, "every rail button names a real category");
+
+  // no node may be unreachable: that is the failure mode of a hand-written menu
+  const std::vector<std::string> reachable = sidebar.all_node_types();
+  check(reachable.size() == inventory.size(),
+        "every node in the inventory is reachable from the rail");
+
+  bool every_node_present = true;
+  for (const auto &[type, path] : inventory)
+    every_node_present &= std::find(reachable.begin(), reachable.end(), type) !=
+                          reachable.end();
+  check(every_node_present, "no node type is missing from the flyouts");
+
+  // and the menus themselves hold those nodes, not just the bookkeeping vectors
+  int leaf_actions = 0;
+  for (int i = 0; i < sidebar.category_count(); ++i)
+    leaf_actions += count_leaf_actions(sidebar.menu_at(i));
+  check(leaf_actions == static_cast<int>(inventory.size()),
+        "the flyout menus contain exactly the inventory's nodes");
+
+  // a deep path becomes nested submenus, not a flattened list
+  const int erosion = names.indexOf("Erosion");
+  check(erosion >= 0, "the Erosion category exists");
+  if (erosion >= 0)
+  {
+    QMenu *menu = sidebar.menu_at(erosion);
+    int    submenus = 0;
+    for (QAction *action : menu->actions())
+      if (action->menu())
+        ++submenus;
+    check(submenus == 3, "Erosion has one submenu per subcategory");
+    check(find_action(menu, "Thermal") != nullptr,
+          "a node two levels deep is present in the flyout tree");
+  }
+
+  // a category the colour map does not name still gets a usable, stable accent
+  const int boundaries = names.indexOf("Boundaries");
+  check(boundaries >= 0, "an uncoloured category still gets a rail button");
+  if (boundaries >= 0)
+    check(sidebar.node_types_at(boundaries) == std::vector<std::string>{"Bulkify"},
+          "an uncoloured category still lists its nodes");
+
+  // a node sitting directly on a category is reachable without a submenu
+  const int bridges = names.indexOf("Bridges");
+  if (bridges >= 0)
+  {
+    QMenu *menu = sidebar.menu_at(bridges);
+    check(menu->actions().size() == 1 && menu->actions().front()->text() ==
+                                             "BlenderBridge",
+          "a node on a category root is a direct flyout entry");
+  }
+}
+
+void test_node_creation_signal()
+{
+  section("sidebar: node creation");
+
+  NodePaletteSidebar sidebar(sample_inventory(), sample_colors(), NodePaletteStyle{});
+
+  QSignalSpy spy(&sidebar, &NodePaletteSidebar::node_type_selected);
+
+  const int erosion = sidebar.category_names().indexOf("Erosion");
+  QAction  *thermal = find_action(sidebar.menu_at(erosion), "Thermal");
+  check(thermal != nullptr, "the Thermal action exists");
+
+  if (thermal)
+  {
+    thermal->trigger();
+    check(spy.count() == 1, "triggering a flyout entry requests one node");
+    if (spy.count() == 1)
+      check(spy.front().front().value<std::string>() == "Thermal",
+            "the requested node type is the one that was picked");
+  }
+
+  // a submenu entry must work without the menu ever having been popped up along
+  // its parent chain, which is how the flyouts are actually driven
+  QAction *deep = find_action(sidebar.menu_at(erosion), "HydraulicParticle");
+  if (deep)
+  {
+    deep->trigger();
+    check(spy.count() == 2, "a nested entry requests a node too");
+  }
+}
+
+void test_search()
+{
+  section("sidebar: search");
+
+  NodePaletteSidebar sidebar(sample_inventory(), sample_colors(), NodePaletteStyle{});
+
+  QLineEdit *field = sidebar.search_field();
+  check(field != nullptr, "the rail has a search field");
+
+  QCompleter *completer = field ? field->completer() : nullptr;
+  check(completer != nullptr, "the search field is backed by a completer");
+
+  if (!completer)
+    return;
+
+  check(completer->filterMode() == Qt::MatchContains,
+        "search matches anywhere in the entry, not just as a prefix");
+  check(completer->caseSensitivity() == Qt::CaseInsensitive,
+        "search is case insensitive");
+
+  completer->setCompletionPrefix("thermal");
+  check(completer->completionCount() == 1, "searching a node name finds it");
+
+  // the category is part of the searchable text, so a family search works
+  completer->setCompletionPrefix("Erosion");
+  check(completer->completionCount() == 4,
+        "searching a category finds every node in it");
+
+  completer->setCompletionPrefix("zzzz");
+  check(completer->completionCount() == 0, "a nonsense query finds nothing");
+
+  QSignalSpy spy(&sidebar, &NodePaletteSidebar::node_type_selected);
+  field->setText("Clamp");
+  QTest::keyClick(field, Qt::Key_Return);
+  check(spy.count() == 1, "Enter on an exact node name creates it");
+  check(field->text().isEmpty(), "the field clears after creating a node");
+}
+
+void test_flyout_geometry()
+{
+  section("sidebar: flyout geometry at scale");
+
+  // a deliberately oversized style stands in for a large interface scale: the
+  // flyout must still land on the screen and become scrollable rather than
+  // running off the bottom
+  NodePaletteStyle style;
+  style.button_height = 92;
+  style.flyout_row_height = 76;
+  style.icon_size = 44;
+  style.rail_padding = 18;
+
+  // an inventory big enough that one category cannot fit on the test screen
+  std::map<std::string, std::string> inventory;
+  for (int i = 0; i < 120; ++i)
+    inventory["Node" + std::to_string(i)] = "Primitive/Coherent";
+
+  NodePaletteSidebar sidebar(inventory, sample_colors(), style);
+  sidebar.resize(240, 300); // a short, narrow panel
+  sidebar.show();
+  QApplication::processEvents();
+
+  const QRect available = QApplication::primaryScreen()->availableGeometry();
+
+  sidebar.open_category(0);
+  QApplication::processEvents();
+
+  QMenu *menu = sidebar.menu_at(0);
+  check(menu->isVisible(), "the flyout opened");
+  check(sidebar.open_category_index() == 0, "the rail knows which flyout is open");
+  check(sidebar.button_at(0)->is_open(), "the open category is marked on the rail");
+
+  const QRect geom = menu->geometry();
+  check(available.contains(geom, /*proper*/ false) ||
+            (geom.top() >= available.top() && geom.bottom() <= available.bottom() &&
+             geom.left() >= available.left() && geom.right() <= available.right()),
+        "the flyout stays inside the available screen area");
+  check(geom.height() <= available.height(),
+        "the flyout is never taller than the screen (it scrolls instead)");
+
+  sidebar.close_flyout();
+  QApplication::processEvents();
+  check(!menu->isVisible(), "closing the flyout hides it");
+  check(sidebar.open_category_index() == -1, "the rail forgets the closed flyout");
+  check(!sidebar.button_at(0)->is_open(), "the rail button returns to its resting state");
+
+  // the rail itself has to stay reachable in a short panel
+  auto *scroll = sidebar.findChild<QScrollArea *>();
+  check(scroll != nullptr, "the category rail lives in a scroll area");
+  if (scroll)
+  {
+    scroll->widget()->adjustSize();
+    QApplication::processEvents();
+    check(scroll->verticalScrollBar()->maximum() > 0 ||
+              scroll->widget()->height() <= scroll->viewport()->height(),
+          "categories that do not fit can be scrolled to");
+  }
+
+  sidebar.hide();
+}
+
+void test_animation_toggle()
+{
+  section("sidebar: animations");
+
+  NodePaletteStyle style;
+  style.animations = true;
+  style.animation_ms = 400;
+
+  NodePaletteSidebar sidebar(sample_inventory(), sample_colors(), style);
+  sidebar.resize(240, 600);
+  sidebar.show();
+  QApplication::processEvents();
+
+  CategoryRailButton *button = sidebar.button_at(0);
+  check(button->current_surface() == style.surface, "a resting button uses the surface");
+
+  auto hover = [](CategoryRailButton *b, bool on)
+  {
+    if (on)
+    {
+      QEnterEvent event(QPointF(1, 1), QPointF(1, 1), QPointF(1, 1));
+      QApplication::sendEvent(b, &event);
+    }
+    else
+    {
+      QEvent event(QEvent::Leave);
+      QApplication::sendEvent(b, &event);
+    }
+  };
+
+  hover(button, true);
+  check(button->current_surface() != style.surface_hover,
+        "with animations on the hover colour is faded into, not jumped to");
+
+  // switching animations off has to settle whatever is running, immediately
+  NodePaletteStyle still = style;
+  still.animations = false;
+  sidebar.set_style(still);
+  check(button->current_surface() == still.surface_hover,
+        "disabling animations lands on the hover colour at once");
+
+  hover(button, false);
+  check(button->current_surface() == still.surface,
+        "with animations off, leaving settles immediately too");
+
+  hover(button, true);
+  check(button->current_surface() == still.surface_hover,
+        "and entering settles immediately too");
+
+  sidebar.hide();
+}
+
+void test_restyle()
+{
+  section("sidebar: live restyle");
+
+  NodePaletteSidebar sidebar(sample_inventory(), sample_colors(), NodePaletteStyle{});
+
+  NodePaletteStyle style;
+  style.surface = QColor("#101010");
+  style.button_height = 64;
+  style.button_spacing = 14;
+  style.animations = false;
+
+  const int width_before = sidebar.minimumWidth();
+
+  NodePaletteSidebar::restyle_all(style);
+
+  check(sidebar.get_style().surface == QColor("#101010"),
+        "a settings change reaches a sidebar that is already open");
+  check(sidebar.button_at(0)->current_surface() == QColor("#101010"),
+        "the rail buttons repaint with the new surface");
+  check(sidebar.button_at(0)->sizeHint().height() == 64,
+        "spacing and sizing follow the new style");
+
+  // restyling twice with the same values must not creep: the metrics come from
+  // the style every time, they are never multiplied into the widget
+  NodePaletteSidebar::restyle_all(style);
+  NodePaletteSidebar::restyle_all(style);
+  const int width_after = sidebar.minimumWidth();
+  NodePaletteSidebar::restyle_all(style);
+  check(sidebar.minimumWidth() == width_after,
+        "repeated restyles converge instead of compounding");
+  (void)width_before;
+}
+
+/// Suffix identifying this process's actual Qt scaling, for file names.
+QString dpr_tag()
+{
+  const qreal dpr = QApplication::primaryScreen()->devicePixelRatio();
+  return QString::number(dpr, 'f', 2).replace('.', '_');
+}
+
+void test_real_dpi()
+{
+  section("real Qt DPI in this process");
+
+  QScreen    *screen = QApplication::primaryScreen();
+  const qreal dpr = screen->devicePixelRatio();
+  const QRect available = screen->availableGeometry();
+
+  std::cout << "  ..   QT_SCALE_FACTOR='"
+            << qgetenv("QT_SCALE_FACTOR").toStdString() << "' devicePixelRatio " << dpr
+            << " available logical geometry " << available.width() << "x"
+            << available.height() << "\n";
+
+  check(dpr > 0.0, "the screen reports a usable device pixel ratio");
+
+  // untouched defaults: nothing in this test multiplies a metric, so if a
+  // logical size comes out different at a different QT_SCALE_FACTOR then
+  // something in the widget is scaling on top of Qt
+  const NodePaletteStyle style;
+
+  // the nodes go on the category root, not in a subcategory, so the *top-level*
+  // flyout is the one that has to be taller than the screen and scroll
+  std::map<std::string, std::string> inventory = sample_inventory();
+  for (int i = 0; i < 160; ++i)
+    inventory["Node" + std::to_string(i)] = "Primitive";
+
+  NodePaletteSidebar sidebar(inventory, sample_colors(), style);
+  sidebar.resize(sidebar.minimumWidth(), std::min(600, available.height()));
+  sidebar.show();
+  QApplication::processEvents();
+
+  check(sidebar.button_at(0)->sizeHint().height() == style.button_height,
+        "a rail button's logical height is the style's, whatever the scale");
+  check(sidebar.get_style().button_height == style.button_height,
+        "the style itself was not rewritten by being applied");
+  check(sidebar.get_style().flyout_row_height == style.flyout_row_height,
+        "nor was the flyout row height");
+
+  // every flyout, opened through the real popup path at the real scale
+  bool all_on_screen = true;
+  bool none_too_tall = true;
+  int  scrolled = 0;
+
+  for (int i = 0; i < sidebar.category_count(); ++i)
+  {
+    sidebar.open_category(i);
+    QApplication::processEvents();
+
+    QMenu      *menu = sidebar.menu_at(i);
+    const QRect geom = menu->geometry();
+
+    const bool inside = geom.left() >= available.left() &&
+                        geom.right() <= available.right() &&
+                        geom.top() >= available.top() &&
+                        geom.bottom() <= available.bottom();
+
+    if (!inside)
+      std::cout << "  ..   flyout " << sidebar.category_names().at(i).toStdString()
+                << " geometry " << geom.x() << "," << geom.y() << " "
+                << geom.width() << "x" << geom.height() << " outside " << available.x()
+                << "," << available.y() << " " << available.width() << "x"
+                << available.height() << "\n";
+
+    all_on_screen &= inside;
+    none_too_tall &= geom.height() <= available.height();
+
+    if (menu->sizeHint().height() > available.height())
+      ++scrolled;
+  }
+
+  sidebar.close_flyout();
+
+  check(all_on_screen, "every category flyout opens inside the available screen area");
+  check(none_too_tall, "no flyout is taller than the screen");
+  std::cout << "  ..   " << scrolled << " of " << sidebar.category_count()
+            << " flyouts wanted more height than the screen has\n";
+  check(scrolled > 0,
+        "the 160-node category really does overflow the screen, so the clamp above "
+        "was exercised rather than trivially true");
+
+  sidebar.hide();
+}
+
+void render_reference_images()
+{
+  section("sidebar: rendered references");
+
+  auto render = [](NodePaletteSidebar &sidebar, const QString &fname)
+  {
+    sidebar.resize(sidebar.minimumWidth() + 40, 560);
+    sidebar.show();
+    QApplication::processEvents();
+
+    QImage image(sidebar.size(), QImage::Format_ARGB32_Premultiplied);
+    image.fill(QColor("#2b2b2b"));
+    QPainter painter(&image);
+    sidebar.render(&painter);
+    painter.end();
+
+    const bool saved = image.save(fname);
+    check(saved, ("rendered " + fname).toStdString());
+    sidebar.hide();
+  };
+
+  // Named by this process's actual device pixel ratio, and always with the
+  // untouched default style: running the binary under several QT_SCALE_FACTOR
+  // values then produces a real set of scaled renders. Faking the scale by
+  // multiplying the metrics here would only ever show what the metrics do, not
+  // what Qt does with them.
+  const QString tag = dpr_tag();
+
+  {
+    NodePaletteSidebar sidebar(sample_inventory(), sample_colors(), NodePaletteStyle{});
+    render(sidebar, "ui-palette-rail-dpr" + tag + ".png");
+  }
+
+  {
+    // the flyout itself, so the neutral surface and the restrained category
+    // accent can be looked at rather than described
+    NodePaletteSidebar sidebar(sample_inventory(), sample_colors(), NodePaletteStyle{});
+    sidebar.resize(sidebar.minimumWidth() + 40, 560);
+    sidebar.show();
+    QApplication::processEvents();
+
+    const int erosion = sidebar.category_names().indexOf("Erosion");
+    sidebar.open_category(erosion);
+    QApplication::processEvents();
+
+    QMenu *menu = sidebar.menu_at(erosion);
+    QTest::qWait(120);
+    std::cout << "  ..   flyout logical size " << menu->width() << "x" << menu->height()
+              << "\n";
+    check(menu->grab().save("ui-palette-flyout-dpr" + tag + ".png"),
+          "rendered ui-palette-flyout");
+
+    QMenu *sub = nullptr;
+    for (QAction *action : menu->actions())
+      if (action->menu())
+      {
+        sub = action->menu();
+        break;
+      }
+
+    if (sub)
+    {
+      sub->popup(menu->mapToGlobal(QPoint(menu->width(), 0)));
+      QTest::qWait(120);
+      check(sub->grab().save("ui-palette-flyout-nodes-dpr" + tag + ".png"),
+            "rendered ui-palette-flyout-nodes");
+      sub->close();
+    }
+
+    sidebar.close_flyout();
+    sidebar.hide();
+  }
+
+  {
+    // the settings dialog at this scale, capped to the real screen
+    ScrollableDialog dialog(make_settings_stub(40), "Application Settings");
+    dialog.show();
+    QApplication::processEvents();
+    QTest::qWait(80);
+    check(dialog.grab().save("ui-settings-dialog-dpr" + tag + ".png"),
+          "rendered ui-settings-dialog");
+    dialog.hide();
+  }
+}
+
+int main(int argc, char *argv[])
+{
+  QApplication app(argc, argv);
+
+  // the sidebar's activation signals carry std::string, like the library tree's
+  qRegisterMetaType<std::string>("std::string");
+
+  test_scale_sanitizing();
+  test_scale_never_compounds();
+  test_scale_malformed_config();
+  test_scale_environment_override();
+  test_executable_path();
+
+  test_settings_dialog();
+
+  test_category_completeness();
+  test_node_creation_signal();
+  test_search();
+  test_flyout_geometry();
+  test_animation_toggle();
+  test_restyle();
+  test_real_dpi();
+  render_reference_images();
+
+  std::cout << "\n" << (g_failures == 0 ? "ALL PASSED" : "FAILURES") << ": "
+            << g_failures << " failing check(s)\n";
+
+  return g_failures == 0 ? 0 : 1;
+}


### PR DESCRIPTION
adds a global scale setting + an optional category sidebar for the node library. mostly so the ui is actually usable at different sizes, and so the node list isnt so cramped.

**scale**
goes from 50% to 300%, theres a reset to 100%. applied through Qt at startup so fonts, icons and fixed size widgets all scale together. changing it needs a restart. also made the settings dialog scrollable, and saved window geometry gets clamped to the available screen now (otherwise you can lose the window on a monitor thats no longer there).

**sidebar**
loosely based on gaea — category buttons that open searchable, hierarchical node menus. reuses hesiods existing node inventory and creation actions, nothing new on that side. the old tree is still the default, switching designs needs a restart. colors, spacing and animation duration are configurable and animations can be turned off completely. click / ctrl-click / shift-click all work. drag and drop does not (yet).

**what i tested**
rebuilt + ran the regression target from this branch against latest dev → 130 checks passed
during implementation the full windows app build passed, and the suite passed in seperate processes at 50 / 100 / 150 / 200 / 300% qt scale. those runs used the dev checkout though, the full app has not been rebuilt from this isolated branch
the scale sweep caught a long-menu overflow bug, fixed by scrolling the menus and clamping their geometry
still needs manual testing, mainly flyout hover behaviour and mixed-monitor setups. the settings dialog wrapper is tested, the full settings pane isnt

**scope**
this pr is only the scaling/sidebar work. none of the other local graph editor or renderer changes are in here, and submodule pins are untouched.