### PR TITLE
build(nix): include bridges/ in the package source

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -37,6 +37,7 @@
             ./cmake
             ./external
             ./Hesiod
+            ./bridges
             ./LICENSE
           ];
         };

--- a/nix/package.nix
+++ b/nix/package.nix
@@ -95,6 +95,10 @@ stdenv.mkDerivation (finalAttrs: {
     # The build writes `git describe` output here; the sandbox has no .git.
     echo "v${finalAttrs.version}" > $out/share/hesiod/data/git_version.txt
 
+    # Blender bridge add-on, ready to install from Blender's preferences.
+    install -Dm644 $src/bridges/Blender/hesiod_streamer.zip \
+      $out/share/hesiod/blender/hesiod_streamer.zip
+
     install -Dm644 $src/Hesiod/data/hesiod_icon.png \
       $out/share/icons/hicolor/512x512/apps/hesiod.png
     install -Dm644 ${./hesiod.desktop} $out/share/applications/hesiod.desktop


### PR DESCRIPTION
Follow-up to #762. The Blender bridge packaging commit (dd718fb4) merged right before it added `add_subdirectory(bridges)` to the root CMakeLists, and the flake's filtered package source did not include `bridges/`, so building dev from the flake fails at configure:

```
CMake Error at CMakeLists.txt:77 (add_subdirectory):
  add_subdirectory given source "bridges" which is not an existing directory.
```

- `flake.nix`: add `./bridges` to the package source. The zip target is not part of `ALL`, so nothing extra is built.
- `nix/package.nix`: install the tracked `bridges/Blender/hesiod_streamer.zip` under `share/hesiod/blender/` so users who install Hesiod from the flake get the add-on too.

Note for future changes: a new top-level `add_subdirectory(...)` in the root CMakeLists needs the matching directory added to the `fileset` list in `flake.nix`.

Verified: `nix build` of this branch from a worktree with no submodules checked out (Nix fetched them over https from the pinned gitlinks) produces a working binary, v0.6.0+20642c7, with the add-on zip installed.
